### PR TITLE
New layers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "BWEnv/include/libzmq"]
 	path = BWEnv/include/libzmq
-	url = git@github.com:torchcraft/libzmq
+	url = https://github.com/TorchCraft/libzmq
 [submodule "BWEnv/include/czmq"]
 	path = BWEnv/include/czmq
-	url = git@github.com:torchcraft/czmq
+	url = https://github.com/torchcraft/czmq

--- a/BWEnv/include/ZMQ_server.h
+++ b/BWEnv/include/ZMQ_server.h
@@ -19,7 +19,7 @@ class Controller;
 
 class ZMQ_server
 {
-  static const int protocol_version = 15;
+  static const int protocol_version = 16;
   static const int max_commands = 400; // maximum number of commands per frame
   static const int starting_port = 11111;
   static const int max_instances = 1000;

--- a/BWEnv/src/controller.cc
+++ b/BWEnv/src/controller.cc
@@ -782,17 +782,11 @@ void Controller::addUnit(BWAPI::Unit u, replayer::Frame& frame, BWAPI::PlayerInt
     + utype.airWeapon().damageBonus()
     * player->getUpgradeLevel(utype.airWeapon().upgradeType()))
     * utype.maxAirHits() * utype.airWeapon().damageFactor();
-  int max_health = utype.maxHitPoints();
-  int hp = 0;
-  if (utype.isMineralField() || utype == BWAPI::UnitTypes::Resource_Vespene_Geyser)
-    hp = u->getResources();
-  else
-    hp = u->getHitPoints();
 
   frame.units[player->getID()].push_back({
     u->getID(), x_wt, y_wt,
-    hp, max_health,
-    u->getShields(), u->getEnergy(),
+    u->getHitPoints(), utype->getMaxHitPoints(),
+    u->getShields(), utype->getMaxShields(),u->getEnergy(),
     player->weaponDamageCooldown(utype),
     u->getGroundWeaponCooldown(), u->getAirWeaponCooldown(),
     u->isIdle(), u->isVisible(),
@@ -813,7 +807,9 @@ void Controller::addUnit(BWAPI::Unit u, replayer::Frame& frame, BWAPI::PlayerInt
     u->getVelocityX(),
     u->getVelocityY(),
     unit_player,
+    u->getResources()
   });
+
 
   // Add curent order to order list
   // (we keep Orders::None orders as their timing marks the moment where

--- a/BWEnv/src/controller.cc
+++ b/BWEnv/src/controller.cc
@@ -786,7 +786,7 @@ void Controller::addUnit(BWAPI::Unit u, replayer::Frame& frame, BWAPI::PlayerInt
   frame.units[player->getID()].push_back({
     u->getID(), x_wt, y_wt,
     u->getHitPoints(), utype.maxHitPoints(),
-    u->getShields(), utype.maxShields(),u->getEnergy(),
+    u->getShields(), utype.maxShields(), u->getEnergy(),
     player->weaponDamageCooldown(utype),
     u->getGroundWeaponCooldown(), u->getAirWeaponCooldown(),
     u->isIdle(), u->isVisible(),

--- a/BWEnv/src/controller.cc
+++ b/BWEnv/src/controller.cc
@@ -785,8 +785,8 @@ void Controller::addUnit(BWAPI::Unit u, replayer::Frame& frame, BWAPI::PlayerInt
 
   frame.units[player->getID()].push_back({
     u->getID(), x_wt, y_wt,
-    u->getHitPoints(), utype->getMaxHitPoints(),
-    u->getShields(), utype->getMaxShields(),u->getEnergy(),
+    u->getHitPoints(), utype.maxHitPoints(),
+    u->getShields(), utype.maxShields(),u->getEnergy(),
     player->weaponDamageCooldown(utype),
     u->getGroundWeaponCooldown(), u->getAirWeaponCooldown(),
     u->isIdle(), u->isVisible(),

--- a/examples/tensor_example.lua
+++ b/examples/tensor_example.lua
@@ -1,0 +1,197 @@
+--[[
+   Copyright (c) 2015-present, Facebook, Inc.
+   All rights reserved.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree. An additional grant
+   of patent rights can be found in the PATENTS file in the same directory.
+]]--
+
+require 'torch'
+torch.setdefaulttensortype('torch.FloatTensor')
+require 'sys'
+require 'gnuplot'
+local stringx = require 'pl.stringx'
+local tablex = require 'pl.tablex'
+local lapp = require 'pl.lapp'
+
+local args = lapp [[
+    Baselines for Starcraft
+    -t,--hostname       (default "")    Give hostname / ip pointing to VM
+    -p,--port           (default 11111) Port for torchcraft. Do 0 to grab vm from cloud
+    -s,--skip_frames    (default 240)     Number of frames to skip per calculation
+    -m,--micro_game     (default true)  Set to false to run on a normal map (test resource layers)
+    -f,--feature        (default hp) select what feature to view
+    ]]
+
+local skip_frames = args.skip_frames
+print("skip frames:", skip_frames)
+local max_battles = 10
+local port = args.port
+local hostname = args.hostname or ""
+local micro_game = args.micro_game
+local test_feature = args.feature
+print("hostname:", hostname)
+print("max battles:", max_battles)
+print("micro_game:", micro_game)
+
+require 'progressbar'
+local progress = ProgressBar(-1)
+progress.mutex = {lock = function() end, unlock = function() end}
+progress:singleThreaded()
+
+local tc = require 'torchcraft'
+local utils = require 'torchcraft.utils'
+local replayer = require 'torchcraft.replayer'
+local isFlyer = tc.staticdata.isFlyer
+
+local available_actions = {
+    tc.usercmd.Move_Screen_Up,
+    tc.usercmd.Move_Screen_Down,
+    tc.usercmd.Move_Screen_Left,
+    tc.usercmd.Move_Screen_Right
+}
+-- ~~~~~~~~~~~~ INITIALIZATION ~~~~~~~~~~~~~
+
+local battles_game = 0
+local frames_in_battle = 1
+local last_frame_from_bwapi = 0
+local nloop = 1
+
+if micro_game then
+    tc.initial_map = 'Maps/Broodwar/dragoons_zealots.scm'
+else
+    tc.initial_map = 'Maps/ICCup/ICCup Python 1.3.scx'
+end
+
+tc.window_pos = {200, 200}
+tc.window_size = {320, 240}
+tc.mode.micro_battles = micro_game
+tc.mode.replay = false
+
+tc:init(hostname, port)
+local update = tc:connect(port)
+
+-- first message from the BWAPI side is setting up variables
+tc:set_variables()
+
+tc:send({table.concat({
+                 tc.command(tc.set_speed, 15), -- 13 is max speed without frame not being updated
+                 tc.command(tc.set_gui, 1),
+                 tc.command(tc.set_frameskip, 5),
+                 tc.command(tc.set_cmd_optim, 1),
+                 tc.command(tc.set_combine_frames, skip_frames)
+                      }, ':')})
+
+print("\nMap name: ", tc.state.map_name)
+
+-- ~~~~~~~~~~~~~~ LOOP ~~~~~~~~~~~~~~~
+
+local save_continuous = true
+local cstr = ""
+local img_counter = 0
+
+local tensor_to_string = torch.Tensor.__tostring__
+
+local tm = torch.Timer()
+while not tc.state.game_ended do
+    -- progress bar
+    progress:add('Loop', nloop, '%7d')
+    progress:add('FPS', 1 / tm:time().real, '%7d')
+    if micro_game then
+        progress:add('#Bttls', battles_game, '%7d')
+    end
+    progress:push()
+    tm:reset()
+
+    -- update turn data
+    update = tc:receive()
+    nloop = nloop + 1
+    local actions = {}
+
+    if tc.state.game_ended then
+        break
+
+    elseif microgame and tc.state.battle_just_ended then
+        battles_game = battles_game + 1
+        frames_in_battle = 0
+        if battles_game >= max_battles then -- this is an example
+            actions = {tc.command(tc.quit)}
+        end
+
+    elseif microgame and tc.state.waiting_for_restart then
+        -- do nothing
+
+    else
+        if tc.state.image then
+
+            -- Uncomment the following to check the changing screen position
+            -- print(tc.state.screen_position)
+
+            -- Uncomment the following to list units (and whether they are in the
+            -- screen or not)
+            -- for uid, ut in pairs(tc.state.units_myself) do
+            --     print("Unit " .. uid .. " in screen: " .. tostring(tc:is_unit_in_screen(ut)))
+            -- end
+            local hp_tensor         = tc:get_feature("hp",         true, "short")
+            local type_tensor       = tc:get_feature("type",       true, "byte")
+            local player_tensor     = tc:get_feature("playerId",   true)
+            local visibility_tensor = tc:get_feature("visibility", true)
+            local minerals_tensor   = tc:get_feature("minerals",   true, "short")
+            local gas_tensor        = tc:get_feature("gas",        true, "short")
+            local energy_tensor     = tc:get_feature("energy",     true)
+            local shield_tensor     = tc:get_feature("shield",     true, "short")
+
+            if save_continuous then
+                cstr = string.format("%05d", img_counter)
+                img_counter = img_counter + 1
+            end
+
+            --                     #justvimthings V
+            if     test_feature == "hp" then
+                gnuplot.imagesc(hp_tensor         ,'color')
+            elseif test_feature == "type" then
+                gnuplot.imagesc(type_tensor       ,'color')  
+            elseif test_feature == "player" then
+                gnuplot.imagesc(player_tensor     ,'color')
+            elseif test_feature == "visibility" then
+                gnuplot.imagesc(visibility_tensor ,'color')
+            elseif test_feature == "minerals" then
+                gnuplot.imagesc(minerals_tensor   ,'color')
+            elseif test_feature == "gas" then
+                gnuplot.imagesc(gas_tensor        ,'color')
+            elseif test_feature == "energy" then
+                gnuplot.imagesc(energy_tensor     ,'color')
+            elseif test_feature == "shield" then
+                gnuplot.imagesc(shield_tensor     ,'color')
+            end
+            
+        end
+
+        -- Choose random screen action
+        act = available_actions[math.random(#available_actions)]
+        -- table.insert(actions, tc.command(tc.command_user, act, 10))
+        table.insert(actions, tc.command(tc.noop))
+
+        if tc.state.frame_from_bwapi > last_frame_from_bwapi then
+            frames_in_battle = frames_in_battle + 1
+            last_frame_from_bwapi = tc.state.frame_from_bwapi
+        end
+
+        progress:pop()
+    end
+
+    table.insert(actions,
+                 tc.command(tc.request_image))
+
+    tc:send({table.concat(actions, ':')})
+end
+
+tc:send({table.concat({
+    tc.command(tc.exit_process)
+}, ':')})
+
+os.execute("sleep 0.5")
+print("")
+print()
+collectgarbage()
+collectgarbage()

--- a/examples/tensor_example.lua
+++ b/examples/tensor_example.lua
@@ -132,14 +132,16 @@ while not tc.state.game_ended do
             -- for uid, ut in pairs(tc.state.units_myself) do
             --     print("Unit " .. uid .. " in screen: " .. tostring(tc:is_unit_in_screen(ut)))
             -- end
-            local hp_tensor         = tc:get_feature("hp",         true, "short")
-            local type_tensor       = tc:get_feature("type",       true, "byte")
+
+            local hp_tensor         = tc:get_feature("hp",         true)
+            local type_tensor       = tc:get_feature("type",       true)
             local player_tensor     = tc:get_feature("playerId",   true)
             local visibility_tensor = tc:get_feature("visibility", true)
-            local minerals_tensor   = tc:get_feature("minerals",   true, "short")
-            local gas_tensor        = tc:get_feature("gas",        true, "short")
+            local minerals_tensor   = tc:get_feature("minerals",   true)
+            local gas_tensor        = tc:get_feature("gas",        true)
             local energy_tensor     = tc:get_feature("energy",     true)
-            local shield_tensor     = tc:get_feature("shield",     true, "short")
+            local shield_tensor     = tc:get_feature("shield",     true)
+
 
             if save_continuous then
                 cstr = string.format("%05d", img_counter)

--- a/examples/visual_example.lua
+++ b/examples/visual_example.lua
@@ -18,7 +18,8 @@ local args = lapp [[
     Baselines for Starcraft
     -t,--hostname       (default "")    Give hostname / ip pointing to VM
     -p,--port           (default 11111) Port for torchcraft. Do 0 to grab vm from cloud
-    -s,--skip_frames    (default 2)     Number of frames to skip per calculation
+    -s,--skip_frames    (default 30)     Number of frames to skip per calculation
+    -m,--micro_game     (default true)  Set to false to run on a normal map (test resource layers)
     ]]
 
 local skip_frames = args.skip_frames
@@ -26,8 +27,10 @@ print("skip frames:", skip_frames)
 local max_battles = 10
 local port = args.port
 local hostname = args.hostname or ""
+local micro_game = args.micro_game
 print("hostname:", hostname)
 print("max battles:", max_battles)
+print("micro_game:", micro_game)
 
 require 'progressbar'
 local progress = ProgressBar(-1)
@@ -56,7 +59,7 @@ tc.initial_map = 'Maps/BroodWar/micro/m5v5_c_far.scm'
 
 tc.window_pos = {200, 200}
 tc.window_size = {320, 240}
-tc.mode.micro_battles = true
+tc.mode.micro_battles = micro_game
 tc.mode.replay = false
 
 tc:init(hostname, port)
@@ -88,7 +91,9 @@ while not tc.state.game_ended do
     -- progress bar
     progress:add('Loop', nloop, '%7d')
     progress:add('FPS', 1 / tm:time().real, '%7d')
-    progress:add('#Bttls', battles_game, '%7d')
+    if micro_game then
+        progress:add('#Bttls', battles_game, '%7d')
+    end
     progress:push()
     tm:reset()
 
@@ -100,14 +105,14 @@ while not tc.state.game_ended do
     if tc.state.game_ended then
         break
 
-    elseif tc.state.battle_just_ended then
+    elseif microgame and tc.state.battle_just_ended then
         battles_game = battles_game + 1
         frames_in_battle = 0
         if battles_game >= max_battles then -- this is an example
             actions = {tc.command(tc.quit)}
         end
 
-    elseif tc.state.waiting_for_restart then
+    elseif microgame and tc.state.waiting_for_restart then
         -- do nothing
 
     else
@@ -121,11 +126,14 @@ while not tc.state.game_ended do
             -- for uid, ut in pairs(tc.state.units_myself) do
             --     print("Unit " .. uid .. " in screen: " .. tostring(tc:is_unit_in_screen(ut)))
             -- end
-
-            local hp_layer = tc:get_layer("hp", true)
-            local type_layer = tc:get_layer("type", true)
-            local player_layer = tc:get_layer("player", true)
+            local hp_layer         = tc:get_layer("hp",         true)
+            local type_layer       = tc:get_layer("type",       true)
+            local player_layer     = tc:get_layer("player",     true)
             local visibility_layer = tc:get_layer("visibility", true)
+            local minerals_layer   = tc:get_layer("minerals",   true)
+            local gas_layer        = tc:get_layer("gas",        true)
+            local energy_layer     = tc:get_layer("energy",     true)
+            local shield_layer     = tc:get_layer("shield",     true)
 
             if save_continuous then
                 cstr = string.format("%05d", img_counter)
@@ -137,6 +145,11 @@ while not tc.state.game_ended do
             image.save("images/layer_type_" .. cstr .. ".ppm", type_layer)
             image.save("images/layer_player_" .. cstr .. ".ppm", player_layer)
             image.save("images/layer_visibility_" .. cstr .. ".ppm", visibility_layer)
+            image.save("images/layer_minerals_" .. cstr .. ".ppm", minerals_layer)
+            image.save("images/layer_gas_" .. cstr .. ".ppm", gas_layer)
+            image.save("images/layer_energy_" .. cstr .. ".ppm", energy_layer)
+            image.save("images/layer_shield_" .. cstr .. ".ppm", shield_layer)
+
         end
 
         -- Choose random screen action

--- a/examples/visual_example.lua
+++ b/examples/visual_example.lua
@@ -146,9 +146,9 @@ while not tc.state.game_ended do
             image.save("images/layer_player_" .. cstr .. ".ppm", player_layer)
             image.save("images/layer_visibility_" .. cstr .. ".ppm", visibility_layer)
             image.save("images/layer_minerals_" .. cstr .. ".ppm", minerals_layer)
-            image.save("images/layer_gas_" .. cstr .. ".ppm", gas_layer)
-            image.save("images/layer_energy_" .. cstr .. ".ppm", energy_layer)
-            image.save("images/layer_shield_" .. cstr .. ".ppm", shield_layer)
+            image.save("images/layer_gas_"      .. cstr .. ".ppm", gas_layer)
+            image.save("images/layer_energy_"   .. cstr .. ".ppm", energy_layer)
+            image.save("images/layer_shield_"   .. cstr .. ".ppm", shield_layer)
 
         end
 

--- a/examples/visual_example.lua
+++ b/examples/visual_example.lua
@@ -145,10 +145,12 @@ while not tc.state.game_ended do
             image.save("images/layer_type_" .. cstr .. ".ppm", type_layer)
             image.save("images/layer_player_" .. cstr .. ".ppm", player_layer)
             image.save("images/layer_visibility_" .. cstr .. ".ppm", visibility_layer)
-            image.save("images/layer_minerals_" .. cstr .. ".ppm", minerals_layer)
-            image.save("images/layer_gas_"      .. cstr .. ".ppm", gas_layer)
-            image.save("images/layer_energy_"   .. cstr .. ".ppm", energy_layer)
             image.save("images/layer_shield_"   .. cstr .. ".ppm", shield_layer)
+            image.save("images/layer_energy_"   .. cstr .. ".ppm", energy_layer)
+            if not micro_game then
+                image.save("images/layer_minerals_" .. cstr .. ".ppm", minerals_layer)
+                image.save("images/layer_gas_"      .. cstr .. ".ppm", gas_layer)
+            end
 
         end
 

--- a/init.lua
+++ b/init.lua
@@ -1294,9 +1294,15 @@ function torchcraft:draw_entity(img, pos_x, pos_y, size_x, size_y, rgb)
                                          math.floor(pos_y - size_y / 2))
     local narrow_height_end = math.min(img:size()[2],
                                        math.floor(pos_y + size_y / 2))
-
+    -- Hack to fix crash were unit is on top left corner of FoV
+    if narrow_width_end <= 0 then
+        narrow_width_end = narrow_width_start
+    end
     local rect = img:narrow(3, narrow_width_start,
-                            narrow_width_end - narrow_width_start)
+                            narrow_width_end - narrow_width_start + 1)
+    if narrow_height_end <= 0 then
+        narrow_height_end = narrow_height_start
+    end
     local rect = rect:narrow(2, narrow_height_start,
                              narrow_height_end - narrow_height_start + 1)
     rect[1]:fill(rgb[1])

--- a/init.lua
+++ b/init.lua
@@ -1333,6 +1333,30 @@ function torchcraft:get_layer(layer_type, also_enemy)
                                        32, 32, color)
             end
         end
+    elseif layer_type == "minerals" then
+        t = self.state.units_neutral
+        for uid, ut in pairs(t) do
+            if self:is_unit_in_screen(ut) and utils.is_mineral_field(ut) then
+                pos_x, pos_y = self:get_unit_screen_pos(ut)
+                color = utils.get_health_color(ut.hp, 1500)
+                print(ut.hp)
+                img = self:draw_entity(img, pos_x, pos_y,
+                                       ut.pixel_size_x, ut.pixel_size_y, color)
+            end
+        end
+    elseif layer_type == "gas" then
+        -- :TODO: add friendly refineries/etc
+        -- need to add interface for calling getResources on a refinery in controller.cc 
+        t = self:filter_type(self.state.units_neutral,
+                {self.unittypes.Resource_Vespene_Geyser})
+        for uid, ut in ipairs(t) do
+            if self:is_in_screen(ut) then
+                pos_x, pos_y = self:get_unit_screen_pos(ut)
+                color = utils.get_health_color(ut.hp, 2500)
+                img = self:draw_entity(img, pos_x, pos_y,
+                                       32, 32, color)
+            end
+        end
     else
         for uid, ut in pairs(t) do
             if self:is_unit_in_screen(ut) then
@@ -1343,6 +1367,12 @@ function torchcraft:get_layer(layer_type, also_enemy)
                     color = utils.html_color_table[ut.type]
                 elseif layer_type == "player" then
                     color = utils.players_color_table[ut.playerId]
+                elseif layer_type == "shield" then
+                    -- :TODO: Add max_shelds to state:
+                    color = utils.get_health_color(ut.shield, ut.max_hp)
+                elseif layer_type == "energy" then
+                    -- :TODO: Add something about max energy / upgrades
+                    color = utils.get_health_color(ut.energy, 250)
                 end
                 img = self:draw_entity(img, pos_x, pos_y,
                                        ut.pixel_size_x, ut.pixel_size_y,

--- a/init.lua
+++ b/init.lua
@@ -517,13 +517,13 @@ function torchcraft:isworker(unittypeid)
         unittypeid == torchcraft.unittypes.Zerg_Drone
 end
 
-function torchcraft:is_mineral_field(unittypeid):
+function torchcraft:is_mineral_field(unittypeid)
     return unittypeid == self.unittypes.Resource_Mineral_Field or
         unittypeid == self.unittypes.Resource_Mineral_Field_Type_2 or
         unittypeid == self.unittypes.Resource_Mineral_Field_Type_3
 end
 
-function torchcraft:is_gas_geyser(unittypeid):
+function torchcraft:is_gas_geyser(unittypeid)
     return unittypeid == self.unittypes.Resource_Vespene_Geyser or
         unittypeid == self.unittypes.Protoss_Assimilator or
         unittypeid == self.unittypes.Terran_Refinery or
@@ -1442,9 +1442,7 @@ function torchcraft:get_feature(feature, also_enemy)
                                        32, 32, value)
             end
         end
-    end
-
-    if feature == "minerals" then
+    elseif feature == "minerals" then
         t = self.state.units_neutral
         for uid, ut in pairs(t) do
             if self:is_unit_in_screen(ut) and self:is_mineral_field(ut.type) then

--- a/init.lua
+++ b/init.lua
@@ -1337,7 +1337,7 @@ function torchcraft:get_layer(layer_type, also_enemy)
         for uid, ut in pairs(t) do
             if self:is_unit_in_screen(ut) and utils.is_mineral_field(ut) then
                 pos_x, pos_y = self:get_unit_screen_pos(ut)
-                color = utils.get_health_color(ut.resources, 1500)
+                color = utils.get_health_color(ut.resource, 1500)
                 img = self:draw_entity(img, pos_x, pos_y,
                                        ut.pixel_size_x, ut.pixel_size_y, color)
             end
@@ -1347,7 +1347,7 @@ function torchcraft:get_layer(layer_type, also_enemy)
         for uid, ut in pairs(t) do
             if self:is_unit_in_screen(ut) and utils.is_gas_geyser(ut) then
                 pos_x, pos_y = self:get_unit_screen_pos(ut)
-                color = utils.get_health_color(ut.resources, 2500)
+                color = utils.get_health_color(ut.resource, 2500)
                 img = self:draw_entity(img, pos_x, pos_y,
                                        ut.pixel_size_x, ut.pixel_size_y, color)
             end
@@ -1356,20 +1356,22 @@ function torchcraft:get_layer(layer_type, also_enemy)
         for uid, ut in pairs(t) do
             if self:is_unit_in_screen(ut) then
                 pos_x, pos_y = self:get_unit_screen_pos(ut)
-                if layer_type == "hp" then
+                if layer_type == "hp" and ut.max_hp > 0 then
                     color = utils.get_health_color(ut.hp, ut.max_hp)
                 elseif layer_type == "type" then
                     color = utils.html_color_table[ut.type]
                 elseif layer_type == "player" then
                     color = utils.players_color_table[ut.playerId]
-                elseif layer_type == "shield" then
+                elseif layer_type == "shield" and ut.shield > 0 then
                     color = utils.get_health_color(ut.shield, ut.max_shield)
                 elseif layer_type == "energy" then
                     color = utils.get_health_color(ut.energy, 250)
                 end
-                img = self:draw_entity(img, pos_x, pos_y,
-                                       ut.pixel_size_x, ut.pixel_size_y,
-                                       color)
+                if color then
+                    img = self:draw_entity(img, pos_x, pos_y,
+                                           ut.pixel_size_x, ut.pixel_size_y,
+                                           color)
+                end
             end
         end
     end
@@ -1377,7 +1379,7 @@ function torchcraft:get_layer(layer_type, also_enemy)
 end
 
 function torchcraft:draw_value(img, pox_x, pos_y, size_x, size_y, value)
-
+    return img
 end
 
 function torchcraft:get_feature(feature, also_enemy)
@@ -1406,7 +1408,7 @@ function torchcraft:get_feature(feature, also_enemy)
             if self:is_unit_in_screen(ut) and utils.is_mineral_field(ut) then
                 pos_x, pos_y = self:get_unit_screen_pos(ut)
                 img = self:draw_value(img, pos_x, pos_y,
-                                    ut.pixel_size_x, ut.pixel_size_y, ut.resources)
+                                    ut.pixel_size_x, ut.pixel_size_y, ut.resource)
             end
         return img
         end
@@ -1416,7 +1418,7 @@ function torchcraft:get_feature(feature, also_enemy)
             if self:is_unit_in_screen(ut) and utils.is_gas_geyser(ut) then
                 pos_x, pos_y = self:get_unit_screen_pos(ut)
                 img = self:draw_value(img, pos_x, pos_y,
-                                    ut.pixel_size_x, ut.pixel_size_y, ut.resources)
+                                    ut.pixel_size_x, ut.pixel_size_y, ut.resource)
             end
         return img
         end

--- a/replayer/frame.cpp
+++ b/replayer/frame.cpp
@@ -12,7 +12,7 @@
 std::ostream& replayer::operator<<(std::ostream& out, const replayer::Unit& o) {
   out << o.id << " " << o.x << " " << o.y << " "
     << o.health << " " << o.max_health << " "
-    << o.shield << " " << o.energy << " " << o.maxCD << " "
+    << o.shield << " " << o.max_shield << " " << o.energy << " " << o.maxCD << " "
     << o.groundCD << " " << o.airCD << " " << o.idle << " "
     << o.visible << " " << o.type << " " << o.armor << " "
     << o.shieldArmor << " " << o.size << " "
@@ -30,11 +30,13 @@ std::ostream& replayer::operator<<(std::ostream& out, const replayer::Unit& o) {
 
   out << o.velocityX << " " << o.velocityY;
   out << " " << o.playerId;
+  out << " " << o.resources;
   return out;
 }
 
 std::istream& replayer::operator>>(std::istream& in, replayer::Unit& o) {
-  in >> o.id >> o.x >> o.y >> o.health >> o.max_health >> o.shield >> o.energy
+  in >> o.id >> o.x >> o.y >> o.health >> o.max_health >> o.shield 
+    >> o.max_shield >> o.energy
     >> o.maxCD >> o.groundCD >> o.airCD >> o.idle >> o.visible >> o.type
     >> o.armor >> o.shieldArmor >> o.size
     >> o.pixel_x >> o.pixel_y >> o.pixel_size_x >> o.pixel_size_y
@@ -54,6 +56,7 @@ std::istream& replayer::operator>>(std::istream& in, replayer::Unit& o) {
 
   in >> o.velocityX >> o.velocityY;
   in >> o.playerId;
+  in >> o.resources:
   return in;
 }
 

--- a/replayer/frame.cpp
+++ b/replayer/frame.cpp
@@ -56,7 +56,7 @@ std::istream& replayer::operator>>(std::istream& in, replayer::Unit& o) {
 
   in >> o.velocityX >> o.velocityY;
   in >> o.playerId;
-  in >> o.resources:
+  in >> o.resources;
   return in;
 }
 

--- a/replayer/frame.h
+++ b/replayer/frame.h
@@ -42,7 +42,7 @@ namespace replayer {
 
   struct Unit {
     int32_t id, x, y;
-    int32_t health, max_health, shield, energy;
+    int32_t health, max_health, shield, max_shield, energy;
     int32_t maxCD, groundCD, airCD;
     bool idle, visible;
     int32_t type, armor, shieldArmor, size;
@@ -59,6 +59,8 @@ namespace replayer {
     double velocityX, velocityY;
 
     int32_t playerId;
+
+    int32_t resources;
   };
 
   std::ostream& operator<<(std::ostream& out, const Unit& o);

--- a/replayer/frame_lua.cpp
+++ b/replayer/frame_lua.cpp
@@ -200,7 +200,7 @@ void toFrame(lua_State* L, int id, Frame& res) {
       unit.airATK = getInt(L, "awattack");
       unit.airDmgType = getInt(L, "awdmgtype");
       unit.airRange = getInt(L, "awrange");
-      unit.resources = getInt(L, "resources");
+      unit.resources = getInt(L, "resource");
 
       //commands
       getField(L, "orders");
@@ -301,7 +301,7 @@ void pushUnit(lua_State* L, const Unit& unit) {
   setInt(L, "awdmgtype", unit.airDmgType);
   setInt(L, "gwrange", unit.groundRange);
   setInt(L, "awrange", unit.airRange);
-  setInt(L, "resources", unit.resources);
+  setInt(L, "resource", unit.resources);
 
   // orders
   lua_pushstring(L, "orders");

--- a/replayer/frame_lua.cpp
+++ b/replayer/frame_lua.cpp
@@ -200,6 +200,7 @@ void toFrame(lua_State* L, int id, Frame& res) {
       unit.airATK = getInt(L, "awattack");
       unit.airDmgType = getInt(L, "awdmgtype");
       unit.airRange = getInt(L, "awrange");
+      unit.resources = getInt(L, "resources");
 
       //commands
       getField(L, "orders");
@@ -277,10 +278,10 @@ void pushUnit(lua_State* L, const Unit& unit) {
   lua_settable(L, -3);
 
   setInt(L, "type", unit.type);
-
   setInt(L, "hp", unit.health);
   setInt(L, "max_hp", unit.max_health);
   setInt(L, "shield", unit.shield);
+  setInt(L, "max_shield", unit.max_shield);
   setInt(L, "energy", unit.energy);
   setInt(L, "maxcd", unit.maxCD);
   setInt(L, "gwcd", unit.groundCD);
@@ -300,6 +301,7 @@ void pushUnit(lua_State* L, const Unit& unit) {
   setInt(L, "awdmgtype", unit.airDmgType);
   setInt(L, "gwrange", unit.groundRange);
   setInt(L, "awrange", unit.airRange);
+  setInt(L, "resources", unit.resources);
 
   // orders
   lua_pushstring(L, "orders");

--- a/utils.lua
+++ b/utils.lua
@@ -290,21 +290,6 @@ function utils.get_health_color(hp_percentage, max_hp)
     return utils.hsv_to_rgb({hp_percentage, 100, 100})
 end
 
-function utils.is_mineral_field(ut)
-    if 176 <= ut.type and ut.type <= 178 then
-        return true
-    end
-    return false 
-end
-
-function utils.is_gas_geyser(ut)
-    if ut.type == 188 or ut.type == 157
-    or ut.type == 149 or ut.type == 110 then
-        return true
-    end
-    return false 
-end
-
 utils.visibility_color_table = {
     [0] = {0, 0, 0},       -- black
     [1] = {176,224,230},   -- powder blue

--- a/utils.lua
+++ b/utils.lua
@@ -290,6 +290,13 @@ function utils.get_health_color(hp_percentage, max_hp)
     return utils.hsv_to_rgb({hp_percentage, 100, 100})
 end
 
+function utils.is_mineral_field(ut)
+    if 176 <= ut.type and ut.type <= 178 then
+        return true
+    end
+    return false 
+end
+
 utils.visibility_color_table = {
     [0] = {0, 0, 0},       -- black
     [1] = {176,224,230},   -- powder blue

--- a/utils.lua
+++ b/utils.lua
@@ -297,6 +297,14 @@ function utils.is_mineral_field(ut)
     return false 
 end
 
+function utils.is_gas_geyser(ut)
+    if ut.type == 188 or ut.type == 157
+    or ut.type == 149 or ut.type == 110 then
+        return true
+    end
+    return false 
+end
+
 utils.visibility_color_table = {
     [0] = {0, 0, 0},       -- black
     [1] = {176,224,230},   -- powder blue


### PR DESCRIPTION
- Added max shields and resources as unit data. Resources was separated from HP so that resources of Refineries and such can be seen.
- Added minerals, gas, energy and shields to get_layer and visual example.lua
- Added function is_gas_geyser to utils.lua
- Added functions get_feature and draw_values to init.lua
    - get_feature is similar to get_layer, but outputs a 2D tensor instead of a 3D RGB tensor
    - get_feature does not preform any scaling on values unlike get_layer, besides adding 1 to certain 0 indexed values
    - draw_values is get_features version of draw_entities
    - get_feature can handle any member variable of units, although some tweaking may be required for untested types
    - added test script tensor_example.lua to examples. All cases used in this script have been tested.
- Fixed a bug in get_layer where a unit being in the top-left corner of the screen could cause the script to crash
- Changed default skip_frames in visual_example.lua to 30 to save disk space.
- Added option --micro_game to visual_example.lua for testing of resource layers (mins/gas)
- Added compiled BWEnv.exe and BWEnv.dll
