### PR TITLE
Use 11111 as default port

### DIFF
--- a/config/torchcraft.ini
+++ b/config/torchcraft.ini
@@ -5,7 +5,7 @@
 ;; if not specified).                                           ;;
 ;;                                                              ;;
 ;;                                                              ;;
-:::::: NOTES ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;; NOTES ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;                                                              ;;
 ;; All the configuration here can be overwritten by environment ;;
 ;; variables as to make it easy to create experiment scripts.   ;;
@@ -21,7 +21,7 @@
 
 ;; Determines which port TorchCraft will use to communicate with the
 ;; client.
-port = 0
+port = 11111
 
 ;; Determines the prefix of the log file
 log_path = C:/tc_data/torchcraft_log_cpp_port_
@@ -35,7 +35,7 @@ img_save_path = C:/tc_data/output_
 ;; Determines which image transmission method will be used
 ;; when carrying the visual data over the network. Possible
 ;; values are:
-;; raw, compressed, save, diff
+;; raw, save
 img_mode = raw
 
 ;; Tells what kind of window manager TorchCraft should expect to deal


### PR DESCRIPTION
The examples assume 11111 as default, so we should the same in the default `torchcraft.ini`.