### PR TITLE
Explicit C++-side client state

### DIFF
--- a/client/client.cpp
+++ b/client/client.cpp
@@ -14,39 +14,81 @@
 
 namespace client {
 
-Client::Client(Connection conn) : conn_(std::move(conn)) {}
+Client::Client(lua_State* L) : L_(L), state_(new State()) {}
+
+Client::~Client() {
+  state_->decref();
+}
+
+bool Client::connect(const std::string& hostname, int port) {
+  clearError();
+  if (conn_) {
+    error_ = "Active connection present";
+    return false;
+  }
+
+  try {
+    conn_.reset(new Connection(hostname, port));
+  } catch (zmq::error_t& e) {
+    error_ = e.what();
+    return false;
+  }
+
+  state_->reset();
+  sent_ = false;
+  return true;
+}
+
+bool Client::close() {
+  clearError();
+  if (!conn_) {
+    error_ = "No active connection";
+    return false;
+  }
+  conn_.reset();
+  return true;
+}
 
 bool Client::init(std::string& dest, Options opts) {
   std::ostringstream ss;
   ss << "protocol=16";
-  if (!opts.initialMap.empty()) {
-    ss << ",map=" << opts.initialMap;
+  if (!opts.initial_map.empty()) {
+    ss << ",map=" << opts.initial_map;
   }
-  if (opts.windowSize[0] >= 0) {
-    ss << ",window_size=" << opts.windowSize[0] << " " << opts.windowSize[1];
+  if (opts.window_size[0] >= 0) {
+    ss << ",window_size=" << opts.window_size[0] << " " << opts.window_size[1];
   }
-  if (opts.windowPos[0] >= 0) {
-    ss << ",window_pos=" << opts.windowPos[0] << " " << opts.windowPos[1];
+  if (opts.window_pos[0] >= 0) {
+    ss << ",window_pos=" << opts.window_pos[0] << " " << opts.window_pos[1];
   }
-  ss << ",micro_mode=" << (opts.microBattles ? "true" : "false");
+  ss << ",micro_mode=" << (opts.micro_battles ? "true" : "false");
 
   clearError();
-  if (!conn_.send(ss.str())) {
+  if (!conn_) {
+    error_ = "No active connection";
+    return false;
+  }
+  if (!conn_->send(ss.str())) {
     std::stringstream ss;
-    ss << "Error sending init request: " << conn_.errmsg() << " ("
-       << conn_.errnum() << ")";
+    ss << "Error sending init request: " << conn_->errmsg() << " ("
+       << conn_->errnum() << ")";
     error_ = ss.str();
     return false;
   }
 
-  if (!conn_.receive(dest)) {
+  std::string reply;
+  if (!conn_->receive(reply)) {
     std::stringstream ss;
-    ss << "Error receiving init reply: " << conn_.errmsg() << " ("
-       << conn_.errnum() << ")";
+    ss << "Error receiving init reply: " << conn_->errmsg() << " ("
+       << conn_->errnum() << ")";
     error_ = ss.str();
     return false;
   }
   sent_ = false;
+
+  // Retain Lua-parsable message for returning updates to Lua-land
+  auto update = state_->update(L_, reply);
+  dest.assign(update);
   return true;
 }
 
@@ -57,10 +99,14 @@ bool Client::send(const std::string& msg) {
     return false;
   }
 
-  if (!conn_.send(msg)) {
+  if (!conn_) {
+    error_ = "No active connection";
+    return false;
+  }
+  if (!conn_->send(msg)) {
     std::stringstream ss;
-    ss << "Error sending request: " << conn_.errmsg() << " (" << conn_.errnum()
-       << ")";
+    ss << "Error sending request: " << conn_->errmsg() << " ("
+       << conn_->errnum() << ")";
     error_ = ss.str();
     return false;
   }
@@ -74,18 +120,29 @@ bool Client::receive(std::string& dest) {
   }
 
   clearError();
-  if (!conn_.poll(30000)) {
+  if (!conn_) {
+    error_ = "No active connection";
+    return false;
+  }
+  if (!conn_->poll(30000)) {
     error_ = "Timeout while waiting for server";
     return false;
   }
-  if (!conn_.receive(dest)) {
+
+  std::string reply;
+  if (!conn_->receive(reply)) {
     std::stringstream ss;
-    ss << "Error receiving reply: " << conn_.errmsg() << " (" << conn_.errnum()
-       << ")";
+    ss << "Error receiving reply: " << conn_->errmsg() << " ("
+       << conn_->errnum() << ")";
     error_ = ss.str();
     return false;
   }
   sent_ = false;
+
+  // Retain Lua-parsable message for returning updates to Lua-land
+  auto update = state_->update(L_, reply);
+  dest.assign(update);
+
   return true;
 }
 

--- a/client/client.h
+++ b/client/client.h
@@ -10,26 +10,40 @@
 #pragma once
 
 #include "connection.h"
+#include "state.h"
+
+extern "C" {
+#include <lua.h>
+}
 
 namespace client {
 
 class Client {
  public:
   struct Options {
-    std::string initialMap;
-    int windowSize[2] = {-1, -1};
-    int windowPos[2] = {-1, -1};
-    bool microBattles = false;
+    std::string initial_map;
+    int window_size[2] = {-1, -1};
+    int window_pos[2] = {-1, -1};
+    bool micro_battles = false;
   };
 
  public:
-  explicit Client(Connection conn);
+  Client(lua_State* L);
+  ~Client();
 
+  bool connect(const std::string& hostname, int port);
+  bool connected() const {
+    return conn_ != nullptr;
+  }
+  bool close();
   bool init(std::string& dest, Options opts = Options());
   bool send(const std::string& msg);
   bool receive(std::string& dest);
   std::string error() const {
     return error_;
+  }
+  State* state() const {
+    return state_;
   }
 
  private:
@@ -37,9 +51,14 @@ class Client {
     error_.clear();
   }
 
-  Connection conn_;
+  std::unique_ptr<Connection> conn_;
+  State* state_;
   bool sent_;
   std::string error_;
+
+  // TODO: lua_State is currently needed for parsing data returned from server.
+  // This won't be necessary once the wire protocol has been reworked.
+  lua_State* L_;
 };
 
 } // namespace client

--- a/client/client_lua.cpp
+++ b/client/client_lua.cpp
@@ -13,103 +13,33 @@
 #include "client.h"
 #include "client_lua.h"
 #include "replayer/frame_lua.h"
+#include "state_lua.h"
 
 namespace {
 
-// client userdata is at index, update is at top of stack
-void updateState(lua_State* L, int index) {
-  // push state table onto stack
-  lua_getuservalue(L, index);
-  lua_getfield(L, -1, "state");
-  // push update onto stack
-  lua_pushvalue(L, -3);
-  lua_pushnil(L);
-  while (lua_next(L, -2) != 0) {
-    lua_pushvalue(L, -2);
-    lua_insert(L, -2);
-    if (!strcmp(lua_tostring(L, -2), "frame")) {
-      lua_pushvalue(L, -1);
-      lua_setfield(L, -5, "frame_string");
-
-      replayer::Frame** f =
-          (replayer::Frame**)lua_newuserdata(L, sizeof(replayer::Frame*));
-      *f = new replayer::Frame();
-      std::istringstream ss(lua_tostring(L, -2));
-      ss >> (**f);
-
-      luaL_getmetatable(L, "torchcraft.Frame");
-      lua_setmetatable(L, -2);
-      lua_remove(L, -2);
-    }
-    lua_settable(L, -5);
-  }
-  lua_pop(L, 3);
-}
-
-// client userdata is at index, value is at top of stack
-void setState(lua_State* L, int index, const char* key) {
-  // push state table onto stack
-  lua_getuservalue(L, index);
-  lua_getfield(L, -1, "state");
-  // push value onto stack
-  lua_pushvalue(L, -3);
-  lua_setfield(L, -2, key);
-  lua_pop(L, 2);
-}
-
-THByteTensor* imageToTensor(const std::string& data) {
-  std::istringstream ss(data);
-  std::string t;
-  std::getline(ss, t, ',');
-  auto width = std::stoi(t);
-  std::getline(ss, t, ',');
-  auto height = std::stoi(t);
-  auto imgdata = data.substr(ss.tellg());
-
-  auto storage = THByteStorage_newWithSize(3 * height * width);
-  auto rgb = storage->data;
-
-  // Incoming binary data is [BGRA,...], which we transform into [R..,G..,B..].
-  int k = 0;
-  for (int a = 2; a >= 0; --a) {
-    int it = a;
-    for (int i = 0; i < height * width; i++) {
-      rgb[k] = imgdata[it];
-      it += 4;
-      ++k;
-    }
-  }
-
-  return THByteTensor_newWithStorage3d(
-      storage, 0, 3, height * width, width, height, height, 1);
+inline client::Client* checkClient(lua_State* L, int index = 1) {
+  auto s = luaL_checkudata(L, index, "torchcraft.Client");
+  luaL_argcheck(L, s != nullptr, index, "'client' expected");
+  return *static_cast<client::Client**>(s);
 }
 
 } // namespace
 
 int newClient(lua_State* L) {
-  auto hostname = luaL_checkstring(L, 1);
-  auto port = luaL_checkint(L, 2);
-  client::Client* cl;
-  try {
-    client::Connection conn(client::Connection(hostname, port));
-    cl = new client::Client(std::move(conn));
-  } catch (zmq::error_t& e) {
-    return luaL_error(L, e.what());
-  }
+  client::Client* cl = new client::Client(L);
   luaT_pushudata(L, cl, "torchcraft.Client");
 
-  // uservalue contains a few raw Lua values
+  // Store Lua wrapped state in uservalue table so that all changes done by Lua
+  // code are persistent.
   lua_newtable(L);
-  lua_newtable(L);
+  pushState(L, cl->state());
   lua_setfield(L, -2, "state");
   lua_setuservalue(L, -2);
-
   return 1;
 }
 
 int freeClient(lua_State* L) {
-  auto cl =
-      static_cast<client::Client*>(luaT_checkudata(L, 1, "torchcraft.Client"));
+  auto cl = checkClient(L);
   delete cl;
   return 0;
 }
@@ -124,15 +54,15 @@ int gcClient(lua_State* L) {
 }
 
 int indexClient(lua_State* L) {
-  auto cl =
-      static_cast<client::Client*>(luaT_checkudata(L, 1, "torchcraft.Client"));
+  auto cl = checkClient(L);
   auto key = luaL_checkstring(L, 2);
 
-  luaL_getmetafield(L, 1, key);
-  if (!lua_isnil(L, -1) && lua_iscfunction(L, -1)) {
-    return 1;
+  if (luaL_getmetafield(L, 1, key)) {
+    if (!lua_isnil(L, -1) && lua_iscfunction(L, -1)) {
+      return 1;
+    }
+    lua_pop(L, 1);
   }
-  lua_pop(L, 1);
 
   lua_getuservalue(L, 1);
   lua_getfield(L, -1, key);
@@ -140,9 +70,34 @@ int indexClient(lua_State* L) {
   return 1;
 }
 
+int connectClient(lua_State* L) {
+  auto cl = checkClient(L);
+  auto hostname = luaL_checkstring(L, 2);
+  auto port = luaL_checkint(L, 3);
+  if (!cl->connect(hostname, port)) {
+    auto err = "connect failed: " + cl->error();
+    return luaL_error(L, err.c_str());
+  }
+  return 0;
+}
+
+int connectedClient(lua_State* L) {
+  auto cl = checkClient(L);
+  lua_pushboolean(L, cl->connected());
+  return 1;
+}
+
+int closeClient(lua_State* L) {
+  auto cl = checkClient(L);
+  if (!cl->close()) {
+    auto err = "close failed: " + cl->error();
+    return luaL_error(L, err.c_str());
+  }
+  return 0;
+}
+
 int initClient(lua_State* L) {
-  auto cl =
-      static_cast<client::Client*>(luaT_checkudata(L, 1, "torchcraft.Client"));
+  auto cl = checkClient(L);
   client::Client::Options opts;
   if (lua_gettop(L) > 1) {
     if (!lua_istable(L, 2)) {
@@ -151,16 +106,16 @@ int initClient(lua_State* L) {
 
     lua_getfield(L, 2, "initial_map");
     if (!lua_isnil(L, -1)) {
-      opts.initialMap = lua_tostring(L, -1);
+      opts.initial_map = lua_tostring(L, -1);
     }
     lua_pop(L, 1);
 
     lua_getfield(L, 2, "window_size");
     if (!lua_isnil(L, -1)) {
       lua_rawgeti(L, -1, 1);
-      opts.windowSize[0] = lua_toboolean(L, -1);
+      opts.window_size[0] = lua_toboolean(L, -1);
       lua_rawgeti(L, -2, 2);
-      opts.windowSize[1] = lua_toboolean(L, -1);
+      opts.window_size[1] = lua_toboolean(L, -1);
       lua_pop(L, 2);
     }
     lua_pop(L, 1);
@@ -168,16 +123,16 @@ int initClient(lua_State* L) {
     lua_getfield(L, 2, "window_pos");
     if (!lua_isnil(L, -1)) {
       lua_rawgeti(L, -1, 1);
-      opts.windowPos[0] = lua_toboolean(L, -1);
+      opts.window_pos[0] = lua_toboolean(L, -1);
       lua_rawgeti(L, -2, 2);
-      opts.windowPos[1] = lua_toboolean(L, -1);
+      opts.window_pos[1] = lua_toboolean(L, -1);
       lua_pop(L, 2);
     }
     lua_pop(L, 1);
 
     lua_getfield(L, 2, "micro_battles");
     if (!lua_isnil(L, -1)) {
-      opts.microBattles = lua_toboolean(L, -1);
+      opts.micro_battles = lua_toboolean(L, -1);
     }
     lua_pop(L, 1);
   }
@@ -189,13 +144,11 @@ int initClient(lua_State* L) {
   }
 
   luaL_dostring(L, ("return " + reply).c_str());
-  updateState(L, 1);
   return 1;
 }
 
 int sendClient(lua_State* L) {
-  auto cl =
-      static_cast<client::Client*>(luaT_checkudata(L, 1, "torchcraft.Client"));
+  auto cl = checkClient(L);
   std::string msg;
   if (lua_istable(L, 2)) {
     lua_pushvalue(L, 2);
@@ -227,29 +180,14 @@ int sendClient(lua_State* L) {
 }
 
 int receiveClient(lua_State* L) {
-  auto cl =
-      static_cast<client::Client*>(luaT_checkudata(L, 1, "torchcraft.Client"));
+  auto cl = checkClient(L);
   std::string reply;
   if (!cl->receive(reply)) {
     auto err = "receive failed: " + cl->error();
     return luaL_error(L, err.c_str());
   }
 
-  // Detect optional image in reply from server
-  const char marker[] = "TCIMAGEDATA";
-  auto pos = reply.find(marker);
-  if (pos != std::string::npos) {
-    auto off = pos + sizeof(marker) - 1;
-    auto image = reply.substr(off, reply.length() - off - 2);
-    auto thImage = imageToTensor(image);
-    luaT_pushudata(L, static_cast<void*>(thImage), "torch.ByteTensor");
-    setState(L, 1, "image");
-
-    reply = reply.substr(0, pos) + "}";
-  }
-
   luaL_dostring(L, ("return " + reply).c_str());
-  updateState(L, 1);
   return 1;
 }
 

--- a/client/client_lua.h
+++ b/client/client_lua.h
@@ -20,14 +20,20 @@ extern "C" {
 int newClient(lua_State* L);
 int freeClient(lua_State* L);
 int gcClient(lua_State* L);
+int indexClient(lua_State* L);
+int connectClient(lua_State* L);
+int connectedClient(lua_State* L);
+int closeClient(lua_State* L);
 int initClient(lua_State* L);
 int sendClient(lua_State* L);
 int receiveClient(lua_State* L);
-int indexClient(lua_State* L);
 
 const struct luaL_Reg client_m[] = {
     {"__gc", gcClient},
     {"__index", indexClient},
+    {"connect", connectClient},
+    {"connected", connectedClient},
+    {"close", closeClient},
     {"init", initClient},
     {"send", sendClient},
     {"receive", receiveClient},

--- a/client/lua.cpp
+++ b/client/lua.cpp
@@ -16,9 +16,11 @@ extern "C" {
 }
 
 #include "client_lua.h"
+#include "state_lua.h"
 
 extern "C" int luaopen_torchcraft_client(lua_State* L) {
   lua_newtable(L);
   client::registerClient(L, lua_gettop(L));
+  client::registerState(L, lua_gettop(L));
   return 1;
 }

--- a/client/state.cpp
+++ b/client/state.cpp
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "state.h"
+
+extern "C" {
+#include <TH/TH.h>
+#include <lauxlib.h>
+#include <luaT.h>
+#include <lualib.h>
+}
+
+namespace {
+
+template <typename OutputIt>
+void copyIntegerArray(lua_State* L, int index, OutputIt it, int max = -1) {
+  lua_pushvalue(L, index);
+  int i = 1;
+  while (max < 0 || i <= max) {
+    lua_rawgeti(L, -1, i);
+    if (lua_isnil(L, -1)) {
+      lua_pop(L, 1);
+      break;
+    }
+    *it++ = luaL_checkint(L, -1);
+    lua_pop(L, 1);
+    i++;
+  }
+  lua_pop(L, 1);
+}
+
+template <typename OutputIt>
+void copy2DIntegerArray(lua_State* L, int index, OutputIt it, int size[2]) {
+  lua_pushvalue(L, index);
+
+  int i = 1;
+  int maxj = -1;
+  while (true) {
+    lua_rawgeti(L, -1, i);
+    if (lua_isnil(L, -1) || !lua_istable(L, -1)) {
+      lua_pop(L, 1);
+      break;
+    }
+
+    int j = 1;
+    while (true) {
+      lua_rawgeti(L, -1, j);
+      if (lua_isnil(L, -1)) {
+        lua_pop(L, 1);
+        break;
+      }
+
+      *it++ = luaL_checkint(L, -1);
+      lua_pop(L, 1);
+      j++;
+    }
+
+    lua_pop(L, 1);
+    i++;
+
+    if (maxj < 0) {
+      maxj = j;
+    } else if (maxj != j) {
+      break;
+    }
+  }
+
+  size[0] = i - 1;
+  size[1] = maxj - 1;
+  lua_pop(L, 1);
+}
+
+void copyMapData(
+    lua_State* L,
+    int index,
+    std::vector<uint8_t>& dest,
+    int size[2]) {
+  THByteTensor* data =
+      static_cast<THByteTensor*>(luaT_checkudata(L, index, "torch.ByteTensor"));
+  assert(THByteTensor_nDimension(data) == 2);
+  auto storage = data->storage;
+  auto n = THByteStorage_size(storage);
+  dest.resize(n);
+  memcpy(dest.data(), storage->data, n);
+  size[0] = THByteTensor_size(data, 0);
+  size[1] = THByteTensor_size(data, 1);
+}
+
+} // namespace
+
+namespace client {
+
+State::State() : RefCounted(), frame(new replayer::Frame()) {
+  reset();
+}
+
+State::~State() {
+  frame->decref();
+}
+
+void State::reset() {
+  lag_frames = 0;
+  map_data.clear();
+  map_data_size[0] = 0;
+  map_data_size[1] = 0;
+  map_name.clear();
+  frame_string.clear();
+  deaths.clear();
+  frame_from_bwapi = 0;
+  battle_frame_count = 0;
+  game_ended = false;
+  game_won = false;
+  img_mode.clear();
+  screen_position[0] = -1;
+  screen_position[1] = -1;
+  image.clear(); // XXX invalidates existing tensors pointing to it
+  image_size[0] = 0;
+  image_size[1] = 0;
+}
+
+std::string State::update(lua_State* L, const std::string& msg) {
+  // Detect optional image in reply from server
+  const char marker[] = "TCIMAGEDATA";
+  auto pos = msg.find(marker);
+  std::string update;
+  if (pos != std::string::npos) {
+    auto off = pos + sizeof(marker) - 1;
+    auto imageMsg = msg.substr(off, msg.length() - off - 2);
+    updateImage(imageMsg);
+    update = msg.substr(0, pos) + "}";
+  } else {
+    update = msg;
+  }
+
+  // Parse Lua state update
+  luaL_dostring(L, ("return " + update).c_str());
+
+  // Iterate over update and apply changes
+  lua_pushnil(L);
+  while (lua_next(L, -2) != 0) {
+    std::string key(lua_tostring(L, -2));
+    if (key == "frame") {
+      frame_string = luaL_checkstring(L, -1);
+      std::istringstream ss(frame_string);
+      ss >> *frame;
+    } else if (key == "lag_frames") {
+      lag_frames = luaL_checkint(L, -1);
+    } else if (key == "map_data") {
+      copyMapData(L, -1, map_data, map_data_size);
+    } else if (key == "map_name") {
+      map_name = luaL_checkstring(L, -1);
+    } else if (key == "is_replay") {
+      is_replay = lua_toboolean(L, -1);
+    } else if (key == "player_id") {
+      player_id = luaL_checkint(L, -1);
+    } else if (key == "neutral_id") {
+      neutral_id = luaL_checkint(L, -1);
+    } else if (key == "deaths") {
+      deaths.clear();
+      copyIntegerArray(L, -1, std::inserter(deaths, deaths.begin()));
+    } else if (key == "frame_from_bwapi") {
+      frame_from_bwapi = luaL_checkint(L, -1);
+    } else if (key == "battle_frame_count") {
+      battle_frame_count = luaL_checkint(L, -1);
+    } else if (key == "game_ended") {
+      game_ended = lua_toboolean(L, -1);
+    } else if (key == "game_won") {
+      game_won = lua_toboolean(L, -1);
+    } else if (key == "img_mode") {
+      img_mode = luaL_checkstring(L, -1);
+    } else if (key == "screen_position") {
+      copyIntegerArray(L, -1, screen_position, 2);
+    } else if (key == "visibility") {
+      visibility.clear();
+      copy2DIntegerArray(
+          L,
+          -1,
+          std::inserter(visibility, visibility.begin()),
+          visibility_size);
+    } else {
+      std::cerr << "!! unknown key: " << key << std::endl;
+    }
+
+    lua_pop(L, 1);
+  }
+
+  return update;
+}
+
+void State::updateImage(const std::string& msg) {
+  std::istringstream ss(msg);
+  std::string t;
+  std::getline(ss, t, ',');
+  auto width = std::stoi(t);
+  std::getline(ss, t, ',');
+  auto height = std::stoi(t);
+  auto imgdata = msg.c_str() + ss.tellg();
+
+  image.resize(3 * height * width);
+  auto imgIt = image.begin();
+
+  // Incoming binary data is [BGRA,...], which we transform into [R..,G..,B..].
+  for (int a = 2; a >= 0; --a) {
+    int it = a;
+    for (int i = 0; i < height * width; i++) {
+      *imgIt++ = imgdata[it];
+      it += 4;
+    }
+  }
+
+  image_size[0] = width;
+  image_size[1] = height;
+}
+
+} // namespace client

--- a/client/state.h
+++ b/client/state.h
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+extern "C" {
+#include <lua.h>
+}
+
+#include "replayer/frame.h"
+#include "replayer/refcount.h"
+
+namespace client {
+
+class State : public RefCounted {
+ public:
+  // setup
+  int lag_frames; // number of frames from order to execution
+  std::vector<uint8_t> map_data; // 2D. 255 where not available
+  int map_data_size[2];
+  std::string map_name; // Name on the current map
+  bool is_replay;
+  int player_id;
+  int neutral_id;
+
+  // game state
+  replayer::Frame* frame; // this will allow for easy reset (XXX)
+  std::string frame_string;
+  std::vector<int> deaths;
+  int frame_from_bwapi;
+  int battle_frame_count; // if micro mode
+
+  bool game_ended; // did the game end?
+  bool game_won;
+
+  // if with image
+  std::string img_mode;
+  int screen_position[2]; // position of screen {x, y} in pixels. {0, 0} is
+  // top-left
+  std::vector<uint8_t> visibility;
+  int visibility_size[2];
+  std::vector<uint8_t> image; // RGB
+  int image_size[2];
+
+  State();
+  ~State();
+
+  void reset();
+  std::string update(lua_State* L, const std::string& upd);
+
+ private:
+  void updateImage(const std::string& msg);
+};
+
+} // namespace client

--- a/client/state_lua.cpp
+++ b/client/state_lua.cpp
@@ -1,0 +1,258 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include <set>
+
+#include "replayer/frame_lua.h"
+#include "state_lua.h"
+
+namespace {
+
+inline client::State* checkState(lua_State* L, int index = 1) {
+  auto s = luaL_checkudata(L, index, "torchcraft.State");
+  luaL_argcheck(L, s != nullptr, index, "'state' expected");
+  return *static_cast<client::State**>(s);
+}
+
+int push2DIntegerArray(
+    lua_State* L,
+    const std::vector<uint8_t>& data,
+    int size[2]) {
+  auto it = data.begin();
+  lua_createtable(L, size[0], 0);
+  for (int i = 0; i < size[0]; i++) {
+    lua_createtable(L, size[1], 0);
+    for (int j = 0; j < size[1]; j++) {
+      lua_pushinteger(L, *it++);
+      lua_rawseti(L, -2, j + 1);
+    }
+    lua_rawseti(L, -2, i + 1);
+  }
+  return 1;
+}
+
+const std::set<std::string> stateMembers = {
+    "lag_frames",
+    "map_data",
+    "map_name",
+    "player_id",
+    "neutral_id",
+    "frame",
+    "frame_string",
+    "deaths",
+    "frame_from_bwapi",
+    "battle_frame_count",
+    "game_ended",
+    "game_won",
+    "img_mode",
+    "screen_position",
+    "visibility",
+    "image",
+};
+
+// index represents the index of the state userdata on the stack
+int pushMember(
+    lua_State* L,
+    client::State* s,
+    const std::string& m,
+    int index = 1) {
+  if (m == "lag_frames") {
+    lua_pushinteger(L, s->lag_frames);
+  } else if (m == "map_data") {
+    if (!s->map_data.empty()) {
+      auto s0 = s->map_data_size[0];
+      auto s1 = s->map_data_size[1];
+      auto storage = THByteStorage_newWithData(s->map_data.data(), s0 * s1);
+      THByteStorage_clearFlag(storage, TH_STORAGE_RESIZABLE);
+      THByteStorage_clearFlag(storage, TH_STORAGE_FREEMEM);
+      auto tensor = THByteTensor_newWithStorage2d(storage, 0, s0, s1, s1, 1);
+      luaT_pushudata(L, (void*)tensor, "torch.ByteTensor");
+    } else {
+      lua_pushnil(L);
+    }
+  } else if (m == "map_name") {
+    lua_pushstring(L, s->map_name.c_str());
+  } else if (m == "player_id") {
+    lua_pushinteger(L, s->player_id);
+  } else if (m == "neutral_id") {
+    lua_pushinteger(L, s->neutral_id);
+  } else if (m == "frame") {
+    auto f = (replayer::Frame**)lua_newuserdata(L, sizeof(replayer::Frame*));
+    *f = s->frame;
+    (*f)->incref();
+    luaL_getmetatable(L, "torchcraft.Frame");
+    lua_setmetatable(L, -2);
+  } else if (m == "frame_string") {
+    lua_pushlstring(L, s->frame_string.c_str(), s->frame_string.length());
+  } else if (m == "deaths") {
+    lua_createtable(L, s->deaths.size(), 0);
+    int n = 1;
+    for (auto d : s->deaths) {
+      lua_pushinteger(L, d);
+      lua_rawseti(L, -2, n++);
+    }
+  } else if (m == "frame_from_bwapi") {
+    lua_pushinteger(L, s->frame_from_bwapi);
+  } else if (m == "battle_frame_count") {
+    lua_pushinteger(L, s->battle_frame_count);
+  } else if (m == "game_ended") {
+    lua_pushboolean(L, s->game_ended);
+  } else if (m == "game_won") {
+    lua_pushboolean(L, s->game_won);
+  } else if (m == "img_mode") {
+    lua_pushstring(L, s->img_mode.c_str());
+  } else if (m == "screen_position") {
+    lua_createtable(L, 2, 0);
+    lua_pushinteger(L, s->screen_position[0]);
+    lua_rawseti(L, -2, 1);
+    lua_pushinteger(L, s->screen_position[1]);
+    lua_rawseti(L, -2, 2);
+  } else if (m == "visibility") {
+    push2DIntegerArray(L, s->visibility, s->visibility_size);
+  } else if (m == "image") {
+    if (!s->image.empty()) {
+      auto s0 = s->image_size[0];
+      auto s1 = s->image_size[1];
+      auto storage = THByteStorage_newWithData(s->image.data(), 3 * s0 * s1);
+      THByteStorage_clearFlag(storage, TH_STORAGE_RESIZABLE);
+      THByteStorage_clearFlag(storage, TH_STORAGE_FREEMEM);
+      auto tensor =
+          THByteTensor_newWithStorage3d(storage, 0, 3, s0 * s1, s1, s0, s0, 1);
+      luaT_pushudata(L, (void*)tensor, "torch.ByteTensor");
+    } else {
+      lua_pushnil(L);
+    }
+  } else {
+    lua_getuservalue(L, index);
+    lua_getfield(L, -1, m.c_str());
+    lua_remove(L, -2);
+  }
+  return 1;
+}
+
+} // namespace
+
+int newState(lua_State* L) {
+  return pushState(L);
+}
+
+int pushState(lua_State* L, client::State* state) {
+  auto s = (client::State**)lua_newuserdata(L, sizeof(client::State*));
+  if (state == nullptr) {
+    *s = new client::State();
+  } else {
+    *s = state;
+    state->incref();
+  }
+
+  luaL_getmetatable(L, "torchcraft.State");
+  lua_setmetatable(L, -2);
+
+  lua_newtable(L);
+  lua_setuservalue(L, -2);
+  return 1;
+}
+
+int freeState(lua_State* L) {
+  auto s = checkState(L);
+  s->decref();
+  return 0;
+}
+
+int gcState(lua_State* L) {
+  auto s =
+      static_cast<client::State**>(luaL_checkudata(L, 1, "torchcraft.State"));
+  assert(*s != nullptr);
+  (*s)->decref();
+  *s = nullptr;
+  return 0;
+}
+
+int indexState(lua_State* L) {
+  auto s = checkState(L);
+  auto key = luaL_checkstring(L, 2);
+
+  if (luaL_getmetafield(L, 1, key)) {
+    if (!lua_isnil(L, -1) && lua_iscfunction(L, -1)) {
+      return 1;
+    }
+    lua_pop(L, 1);
+  }
+
+  return pushMember(L, s, key);
+}
+
+int newindexState(lua_State* L) {
+  auto s = checkState(L);
+  auto key = luaL_checkstring(L, 2);
+
+  if (stateMembers.find(key) != stateMembers.end()) {
+    return luaL_error(L, ("Cannot overwrite key " + std::string(key)).c_str());
+  }
+  lua_getuservalue(L, 1);
+  lua_pushvalue(L, 2);
+  lua_pushvalue(L, 3);
+  lua_settable(L, -3);
+  lua_pop(L, 1);
+  return 0;
+}
+
+int resetState(lua_State* L) {
+  auto s = checkState(L);
+  s->reset();
+
+  // TODO: manage these things in State
+  lua_getuservalue(L, 1);
+  for (auto f : std::vector<const char*>({"units",
+                                          "resources",
+                                          "units_myself",
+                                          "units_enemy",
+                                          "resources_myself"})) {
+    lua_newtable(L);
+    lua_setfield(L, -2, f);
+  }
+  lua_pop(L, 1);
+
+  return 0;
+}
+
+int totableState(lua_State* L) {
+  auto s = checkState(L);
+  lua_newtable(L);
+
+  // Add members that are always present
+  for (auto m : stateMembers) {
+    pushMember(L, s, m);
+    lua_setfield(L, -2, m.c_str());
+  }
+
+  // Add user values
+  lua_getuservalue(L, 1);
+  lua_pushnil(L);
+  while (lua_next(L, -2) != 0) {
+    lua_pushvalue(L, -2);
+    lua_insert(L, -2);
+    lua_settable(L, -5);
+  }
+  lua_pop(L, 1);
+  return 1;
+}
+
+namespace client {
+void registerState(lua_State* L, int index) {
+  luaT_newlocalmetatable(
+      L, "torchcraft.State", nullptr, ::newState, ::freeState, nullptr, index);
+  luaL_newmetatable(L, "torchcraft.State");
+  lua_pushvalue(L, -1);
+  lua_setfield(L, -2, "__index");
+  luaT_setfuncs(L, ::state_m, 0);
+  lua_setfield(L, -2, "State");
+  lua_pop(L, 1);
+}
+}

--- a/client/state_lua.cpp
+++ b/client/state_lua.cpp
@@ -25,10 +25,10 @@ int push2DIntegerArray(
     const std::vector<uint8_t>& data,
     int size[2]) {
   auto it = data.begin();
-  lua_createtable(L, size[0], 0);
-  for (int i = 0; i < size[0]; i++) {
-    lua_createtable(L, size[1], 0);
-    for (int j = 0; j < size[1]; j++) {
+  lua_createtable(L, size[1], 0);
+  for (int i = 0; i < size[1]; i++) {
+    lua_createtable(L, size[0], 0);
+    for (int j = 0; j < size[0]; j++) {
       lua_pushinteger(L, *it++);
       lua_rawseti(L, -2, j + 1);
     }

--- a/client/state_lua.h
+++ b/client/state_lua.h
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#pragma once
+
+#include "state.h"
+
+extern "C" {
+
+#include <TH/TH.h>
+#include <lauxlib.h>
+#include <lua.h>
+#include <luaT.h>
+#include <lualib.h>
+
+int newState(lua_State* L);
+int pushState(lua_State* L, client::State* s = nullptr);
+int freeState(lua_State* L);
+int gcState(lua_State* L);
+int indexState(lua_State* L);
+int newindexState(lua_State* L);
+int resetState(lua_State* L);
+int totableState(lua_State* L);
+
+const struct luaL_Reg state_m[] = {
+    {"__gc", gcState},
+    {"__index", indexState},
+    {"__newindex", newindexState},
+    {"reset", resetState},
+    {"toTable", totableState},
+    {nullptr, nullptr},
+};
+
+} // extern "C"
+
+namespace client {
+void registerState(lua_State* L, int index);
+}


### PR DESCRIPTION
This adds a client state definition to the C++ code, including some rudimentary
management logic. The state is attached to the Client object and extensible in
Lua, i.e. it can be used as a normal table for fields that are not pre-defined.

The client functionality has been changed from RAII to explicit initialization
via connect() and close(). This makes life easier in Lua since the same client
and state object can be passed around and will remaining valid after
re-connects.