### PR TITLE
Use flatbuffers for wire protocol (server-side changes)

### DIFF
--- a/BWEnv/VisualStudio/BWEnv.vcxproj
+++ b/BWEnv/VisualStudio/BWEnv.vcxproj
@@ -92,7 +92,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(SolutionDir)/../include;$(SolutionDir)/../include/libzmq/include;$(SolutionDir)../../replayer/;$(SolutionDir)/../include/czmq/include;;$(BWAPI_DIR)/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)/../include;$(SolutionDir)/../include/libzmq/include;$(SolutionDir)../../replayer/;$(SolutionDir)/../include/czmq/include;$(SolutionDir)/../fbs/;$(SolutionDir)/../fbs/;$(BWAPI_DIR)/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -118,7 +118,7 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>$(SolutionDir)/../include;$(SolutionDir)/../include/libzmq/include;$(SolutionDir)../../replayer/;$(SolutionDir)/../include/czmq/include;;$(BWAPI_DIR)/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)/../include;$(SolutionDir)/../include/libzmq/include;$(SolutionDir)../../replayer/;$(SolutionDir)/../include/czmq/include;$(SolutionDir)/../fbs/;;$(BWAPI_DIR)/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -147,7 +147,7 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>$(SolutionDir)/../include;$(SolutionDir)/../include/libzmq/include;$(SolutionDir)../../replayer/;$(SolutionDir)/../include/czmq/include;;$(BWAPI_DIR)/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)/../include;$(SolutionDir)/../include/libzmq/include;$(SolutionDir)../../replayer/;$(SolutionDir)/../include/czmq/include;$(SolutionDir)/../fbs/;;$(BWAPI_DIR)/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;WIN32;NDEBUG;_WINDOWS;_USRDLL;BWENV_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -177,7 +177,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <IntrinsicFunctions>false</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>$(SolutionDir)/../include;$(SolutionDir)/../include/libzmq/include;$(SolutionDir)../../replayer/;$(SolutionDir)/../include/czmq/include;;$(BWAPI_DIR)/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)/../include;$(SolutionDir)/../include/libzmq/include;$(SolutionDir)../../replayer/;$(SolutionDir)/../include/czmq/include;$(SolutionDir)/../fbs/;;$(BWAPI_DIR)/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;WIN32;_DEBUG;_WINDOWS;_USRDLL;BWENV_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <FunctionLevelLinking>

--- a/BWEnv/fbs/messages.fbs
+++ b/BWEnv/fbs/messages.fbs
@@ -21,7 +21,7 @@ table Command {
 }
 
 table HandshakeClient {
-  protocol:int = 17;
+  protocol:int;
   map:string;
   window_size:Vec2;
   window_pos:Vec2;

--- a/BWEnv/fbs/messages_generated.h
+++ b/BWEnv/fbs/messages_generated.h
@@ -216,7 +216,7 @@ struct HandshakeClientT : public flatbuffers::NativeTable {
   std::unique_ptr<Vec2> window_pos;
   bool micro_mode;
   HandshakeClientT()
-    : protocol(17),
+    : protocol(0),
       micro_mode(false) {}
 };
 
@@ -229,7 +229,7 @@ struct HandshakeClient FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_WINDOW_POS = 10,
     VT_MICRO_MODE = 12
   };
-  int32_t protocol() const { return GetField<int32_t>(VT_PROTOCOL, 17); }
+  int32_t protocol() const { return GetField<int32_t>(VT_PROTOCOL, 0); }
   bool mutate_protocol(int32_t _protocol) { return SetField(VT_PROTOCOL, _protocol); }
   const flatbuffers::String *map() const { return GetPointer<const flatbuffers::String *>(VT_MAP); }
   flatbuffers::String *mutable_map() { return GetPointer<flatbuffers::String *>(VT_MAP); }
@@ -256,7 +256,7 @@ struct HandshakeClient FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 struct HandshakeClientBuilder {
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_protocol(int32_t protocol) { fbb_.AddElement<int32_t>(HandshakeClient::VT_PROTOCOL, protocol, 17); }
+  void add_protocol(int32_t protocol) { fbb_.AddElement<int32_t>(HandshakeClient::VT_PROTOCOL, protocol, 0); }
   void add_map(flatbuffers::Offset<flatbuffers::String> map) { fbb_.AddOffset(HandshakeClient::VT_MAP, map); }
   void add_window_size(const Vec2 *window_size) { fbb_.AddStruct(HandshakeClient::VT_WINDOW_SIZE, window_size); }
   void add_window_pos(const Vec2 *window_pos) { fbb_.AddStruct(HandshakeClient::VT_WINDOW_POS, window_pos); }
@@ -270,7 +270,7 @@ struct HandshakeClientBuilder {
 };
 
 inline flatbuffers::Offset<HandshakeClient> CreateHandshakeClient(flatbuffers::FlatBufferBuilder &_fbb,
-    int32_t protocol = 17,
+    int32_t protocol = 0,
     flatbuffers::Offset<flatbuffers::String> map = 0,
     const Vec2 *window_size = 0,
     const Vec2 *window_pos = 0,
@@ -285,7 +285,7 @@ inline flatbuffers::Offset<HandshakeClient> CreateHandshakeClient(flatbuffers::F
 }
 
 inline flatbuffers::Offset<HandshakeClient> CreateHandshakeClientDirect(flatbuffers::FlatBufferBuilder &_fbb,
-    int32_t protocol = 17,
+    int32_t protocol = 0,
     const char *map = nullptr,
     const Vec2 *window_size = 0,
     const Vec2 *window_pos = 0,

--- a/BWEnv/include/ZMQ_server.h
+++ b/BWEnv/include/ZMQ_server.h
@@ -10,23 +10,21 @@
 #ifndef TORCHCRAFT_ZMQ_H_
 #define TORCHCRAFT_ZMQ_H_
 
-#include <sstream>
-
 #include <czmq.h>
 #include "controller.h"
+#include "messages_generated.h"
 
 class Controller;
 
 class ZMQ_server
 {
-  static const int protocol_version = 16;
+  static const int protocol_version = 17;
   static const int max_commands = 400; // maximum number of commands per frame
   static const int starting_port = 11111;
   static const int max_instances = 1000;
 
   Controller *controller;
   zsock_t* server_sock = nullptr;
-  std::stringstream sbuf; /** stringstream buffers for zmq */
   int port = 0;
 public:
   bool server_sock_connected;
@@ -35,17 +33,15 @@ public:
   ~ZMQ_server();
 
   void connect();
-  bool checkForWelcomeMessage(const char*);
-  bool checkProtocolMessage(const char*);
-  std::string checkInitialMap(const char* msg);
-  std::pair<int, int> checkWindowSize(const char* msg);
-  std::pair<int, int> checkWindowPos(const char* msg);
-  bool checkMode(const char* msg);
   void close();
-  void packMessage(const std::string&);
-  void sendMessage();
+  void sendHandshake(const TorchCraft::HandshakeServerT* handshake);
+  void sendFrame(const TorchCraft::FrameT* frame);
+  void sendPlayerLeft(const TorchCraft::PlayerLeftT *pl);
+  void sendEndGame(const TorchCraft::EndGameT *endgame);
+  void sendError(const TorchCraft::ErrorT *error);
   void receiveMessage();
-  void executeTokenize(char*);
+  void handleReconnect(const TorchCraft::HandshakeClient* handshake);
+  void handleCommands(const TorchCraft::Commands* commands);
   int getPort();
 };
 

--- a/BWEnv/include/controller.h
+++ b/BWEnv/include/controller.h
@@ -21,6 +21,8 @@
 #include "config_manager.h"
 #include "recorder.h"
 
+#include "messages_generated.h"
+
 class ZMQ_server;
 
 enum Commands {
@@ -91,6 +93,7 @@ private:
   bool too_long_play_ = false;
   bool exit_process_ = false;
   bool with_image_ = false;
+  TorchCraft::FrameT tcframe_;
 };
 
 #endif // TORCHCRAFT_CONTROL_H_

--- a/BWEnv/include/utils.h
+++ b/BWEnv/include/utils.h
@@ -10,6 +10,10 @@
 #ifndef TORCHCRAFT_UTILS_H_
 #define TORCHCRAFT_UTILS_H_
 
+#include <cstdint>
+#include <vector>
+
+
 namespace Utils
 {
 std::wstring getEnvValue(const wchar_t* env);
@@ -30,6 +34,7 @@ void overwriteConfig(const std::wstring& sc_path_,
 
 // require BWAPI thread
 void bwlog(std::ofstream& output_log, std::string format, ...);
+std::vector<uint8_t> mapToVector();
 std::string mapToTensorStr();
 bool checkTimeInGame();
 std::string ws2s(const std::wstring& ws);

--- a/BWEnv/src/module.cc
+++ b/BWEnv/src/module.cc
@@ -55,9 +55,10 @@ void Module::onPlayerLeft(BWAPI::Player player)
   // Interact verbally with the other players in the game by
   // announcing that the other player has left.
   BWAPI::Broodwar->sendText("Goodbye %s!", player->getName().c_str());
-  this->c_->zmq_server->packMessage(std::string("player_left = '"
-    + player->getName() + "'").c_str());
-  this->c_->zmq_server->sendMessage();
+
+  TorchCraft::PlayerLeftT pl;
+  pl.player_left = player->getName();
+  this->c_->zmq_server->sendPlayerLeft(&pl);
   this->c_->zmq_server->receiveMessage();
 }
 

--- a/BWEnv/src/utils.cc
+++ b/BWEnv/src/utils.cc
@@ -178,6 +178,22 @@ void Utils::bwlog(std::ofstream& output_log,
   va_end(args);
 }
 
+std::vector<uint8_t> Utils::mapToVector()
+{
+  std::vector<uint8_t> v;
+  for (int x = 0; x < BWAPI::Broodwar->mapHeight() * 4; ++x) {
+    for (int y = 0; y < BWAPI::Broodwar->mapWidth() * 4; ++y) {
+      if (BWAPI::Broodwar->isWalkable(x, y)) {
+        v.push_back(BWAPI::Broodwar->getGroundHeight(x / 4, y / 4));
+      } else {
+        v.push_back(-1);
+      }
+      // TODO add isBuildable?
+    }
+  }
+  return v;
+}
+
 std::string Utils::mapToTensorStr()
 {
   std::stringstream r;


### PR DESCRIPTION
These are the server-side changes for changing the wire protocol to flatbuffers.
The code in ZMQ_server.h has been substantially simplified as there's no need to
parse strings anymore.