### PR TITLE
Active unit tracking and end-of-battle detection in client::State

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,12 +17,12 @@ INCLUDE_DIRECTORIES(
 
 ADD_LIBRARY(shared STATIC
     replayer/frame.cpp
+    replayer/frame_lua.cpp
     replayer/gamestore.cpp
     replayer/imgmanager.cpp
     replayer/replayer.cpp)
 
 ADD_LIBRARY(replayer MODULE
-    replayer/frame_lua.cpp
     replayer/init.cpp)
 SET_TARGET_PROPERTIES(replayer PROPERTIES
    PREFIX ""

--- a/client/client.cpp
+++ b/client/client.cpp
@@ -12,6 +12,7 @@
 
 #include "client.h"
 #include "constants.h"
+#include "state.h"
 
 #include "BWEnv/fbs/messages_generated.h"
 
@@ -142,6 +143,8 @@ bool Client::init(std::vector<std::string>& updates, const Options& opts) {
     return false;
   }
 
+  state_->setMicroBattles(opts.micro_battles);
+  state_->setOnlyConsiderTypes(opts.only_consider_types);
   updates = state_->update(
       reinterpret_cast<const TorchCraft::HandshakeServer*>(msg->msg()));
   return true;

--- a/client/client.h
+++ b/client/client.h
@@ -9,8 +9,11 @@
 
 #pragma once
 
+#include <set>
+#include <vector>
+
 #include "connection.h"
-#include "state.h"
+#include "constants.h"
 
 extern "C" {
 #include <lua.h>
@@ -20,6 +23,8 @@ namespace client {
 
 void init();
 
+class State;
+
 class Client {
  public:
   struct Options {
@@ -27,6 +32,10 @@ class Client {
     int window_size[2] = {-1, -1};
     int window_pos[2] = {-1, -1};
     bool micro_battles = false;
+
+    // A subset of unit types to consider when checking for end-of-game
+    // condition, for example.
+    std::set<BW::UnitType> only_consider_types;
   };
 
   struct Command {
@@ -59,6 +68,7 @@ class Client {
     error_.clear();
   }
 
+  // The connection is RAII and is created/reset in init().
   std::unique_ptr<Connection> conn_;
   State* state_;
   bool sent_;

--- a/client/client_lua.cpp
+++ b/client/client_lua.cpp
@@ -12,6 +12,7 @@
 
 #include "client.h"
 #include "client_lua.h"
+#include "lua_utils.h"
 #include "replayer/frame_lua.h"
 #include "state_lua.h"
 
@@ -164,6 +165,12 @@ int initClient(lua_State* L) {
       opts.micro_battles = lua_toboolean(L, -1);
     }
     lua_pop(L, 1);
+
+    lua_getfield(L, 2, "only_consider_types");
+    if (!lua_isnil(L, -1)) {
+      opts.only_consider_types = client::getConsideredTypes(L);
+    }
+    lua_pop(L, 1);
   }
 
   std::vector<std::string> updates;
@@ -197,7 +204,7 @@ int sendClient(lua_State* L) {
     }
     lua_pop(L, 1);
   } else {
-    comms = std::move(parseCommandString(luaL_checkstring(L, 2)));
+    comms = parseCommandString(luaL_checkstring(L, 2));
   }
 
   if (!cl->send(comms)) {

--- a/client/lua_utils.h
+++ b/client/lua_utils.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 extern "C" {
 
@@ -34,8 +35,29 @@ inline void pushValue(lua_State* L, int val) {
 inline void pushValue(lua_State* L, double val) {
   lua_pushnumber(L, val);
 }
+inline void pushValue(lua_State* L, const char* val) {
+  lua_pushstring(L, val);
+}
 inline void pushValue(lua_State* L, const std::string& val) {
   lua_pushstring(L, val.c_str());
+}
+inline void pushValue(lua_State* L, lua_CFunction val) {
+  lua_pushcfunction(L, val);
+}
+template <typename T>
+inline void pushValue(lua_State* L, const std::vector<T>& val) {
+  lua_createtable(L, val.size(), 0);
+  int i = 1;
+  for (const auto& e : val) {
+    pushValue(L, e);
+    lua_rawseti(L, -2, i++);
+  }
+}
+
+template <typename T>
+inline void pushToTable(lua_State* L, int index, const char* key, T val) {
+  pushValue(L, val);
+  lua_setfield(L, index, key);
 }
 
 } // namespace lua

--- a/client/state_lua.h
+++ b/client/state_lua.h
@@ -24,6 +24,7 @@ int indexState(lua_State* L);
 int newindexState(lua_State* L);
 int resetState(lua_State* L);
 int totableState(lua_State* L);
+int setconsiderState(lua_State* L);
 int pushUpdatesState(
     lua_State* L,
     std::vector<std::string>& updates,
@@ -35,11 +36,14 @@ const struct luaL_Reg state_m[] = {
     {"__newindex", newindexState},
     {"reset", resetState},
     {"toTable", totableState},
+    {"setOnlyConsiderTypes", setconsiderState},
     {nullptr, nullptr},
 };
 
 } // extern "C"
 
 namespace client {
+std::set<client::BW::UnitType> getConsideredTypes(lua_State* L, int index = -1);
+
 void registerState(lua_State* L, int index);
 }

--- a/examples/baseline_heuristics.lua
+++ b/examples/baseline_heuristics.lua
@@ -87,8 +87,7 @@ while (first_loop or not one_loop_only)
     battles_game = 0
 
     -- connects to the StarCraft running with BWEnv
-    tc.mode.micro_battles = true
-    tc.mode.replay = false
+    tc.micro_battles = true
 
     tc:init(hostname, port)
     -- first message from the BWAPI side is setting up variables
@@ -106,6 +105,7 @@ while (first_loop or not one_loop_only)
     }, ':')})
 
     print("\nMap name: ", tc.state.map_name)
+    assert(tc.state.replay == false)
     if log_fname ~= "" then
         wf:write("Map name: " .. tc.state.map_name .. '\n')
     end

--- a/examples/self_play_dll.lua
+++ b/examples/self_play_dll.lua
@@ -60,8 +60,7 @@ local nloop = 1
 local maps = {'Maps/BroodWar/micro/sp_dragoons_zealots.scm',
               'Maps/BroodWar/micro/sp_m5v5_c_far.scm'}
 
-tc.mode.micro_battles = true
-tc.mode.replay = false
+tc.micro_battles = true
 
 local nrestarts = 0
 

--- a/examples/simple_dll.lua
+++ b/examples/simple_dll.lua
@@ -57,8 +57,7 @@ local total_battles = 0
 local maps = {'Maps/BroodWar/micro/dragoons_zealots.scm',
               'Maps/BroodWar/micro/m5v5_c_far.scm'}
 
-tc.mode.micro_battles = MICRO_MODE
-tc.mode.replay = false
+tc.micro_battles = MICRO_MODE
 local nrestarts = -1
 
 while total_battles < 40 do
@@ -78,6 +77,7 @@ while total_battles < 40 do
     if DEBUG > 1 then
         print('Received init: ', update)
     end
+    assert(tc.state.replay == false)
 
     -- first message to BWAPI's side is setting up variables
     local setup = {

--- a/examples/simple_exe.lua
+++ b/examples/simple_exe.lua
@@ -58,8 +58,7 @@ local nloop = 1
 local maps = {'Maps/BroodWar/micro/dragoons_zealots.scm',
               'Maps/BroodWar/micro/m5v5_c_far.scm'}
 
-tc.mode.micro_battles = true
-tc.mode.replay = false
+tc.micro_battles = true
 -- This overwrites whatever is in bwapi.ini
 tc.initial_map = maps[2]
 
@@ -70,6 +69,7 @@ local update = tc:connect(port)
 if DEBUG > 1 then
     print('Received init: ', update)
 end
+assert(tc.state.replay == false)
 
 -- first message to BWAPI's side is setting up variables
 local setup = {

--- a/examples/tensor_example.lua
+++ b/examples/tensor_example.lua
@@ -65,8 +65,7 @@ end
 
 tc.window_pos = {200, 200}
 tc.window_size = {320, 240}
-tc.mode.micro_battles = micro_game
-tc.mode.replay = false
+tc.micro_battles = micro_game
 
 tc:init(hostname, port)
 local update = tc:connect(port)
@@ -83,6 +82,7 @@ tc:send({table.concat({
                       }, ':')})
 
 print("\nMap name: ", tc.state.map_name)
+assert(tc.state.replay == false)
 
 -- ~~~~~~~~~~~~~~ LOOP ~~~~~~~~~~~~~~~
 

--- a/examples/visual_example.lua
+++ b/examples/visual_example.lua
@@ -59,8 +59,7 @@ tc.initial_map = 'Maps/BroodWar/micro/m5v5_c_far.scm'
 
 tc.window_pos = {200, 200}
 tc.window_size = {320, 240}
-tc.mode.micro_battles = micro_game
-tc.mode.replay = false
+tc.micro_battles = micro_game
 
 tc:init(hostname, port)
 local update = tc:connect(port)
@@ -77,6 +76,7 @@ tc:send({table.concat({
                       }, ':')})
 
 print("\nMap name: ", tc.state.map_name)
+assert(tc.state.replay == false)
 
 -- ~~~~~~~~~~~~~~ LOOP ~~~~~~~~~~~~~~~
 

--- a/replayer/frame_lua.h
+++ b/replayer/frame_lua.h
@@ -41,6 +41,7 @@ void setBool(lua_State* L, const char* key, bool v);
 bool getField(lua_State* L, const char* key);
 int getInt(lua_State* L, const char* key);
 bool getBool(lua_State* L, const char* key);
+void pushUnit(lua_State* L, const replayer::Unit& unit);
 
 // Lua tables from/to Frame class
 void toFrame(lua_State* L, int id, replayer::Frame& res);


### PR DESCRIPTION
This ports the remaining logic from torchcraft:receive() to the C++ State
object. In particular, client::State now keeps track of units that are alive,
similar to what the Lua code has been doing previously with `units_myself`,
`units_enemy` and so on. Unfortunately, this requires maintaining a
near-duplicate of frame->units so that client code is able to work with the
correct units if frame skipping is enabled on the server (and thus frame->units
might include units that have died since the previous update).

Another significant change is that the `torchcraft.mode` has been removed.
Previously, it was a mix of a setup option (`micro_battles`), a constant
determined by the map (`replay`) and a way to tune end-of-battle detection
(`only_consider_units`). `micro_battles` and `only_consider_units` are now
considered global options, much like `window_size`. `only_consider_units` can be
changed during the game by calling `state:setOnlyConsiderUnits`. `replay` is
simply another read-only field in the state. Note that this will require changes
in existing client code; the examples have been updated accordingly.