### PR TITLE
Removed lzmq dependency from rockspec

### DIFF
--- a/torchcraft-1.0-2.rockspec
+++ b/torchcraft-1.0-2.rockspec
@@ -17,7 +17,6 @@ dependencies = {
     "penlight",
     "tds",
     "lua-cjson",
-    "lzmq",
     "torch >= 7.0",
 }
 build = {


### PR DESCRIPTION
Client-server communication is handled in the C++ client module.