### PR TITLE
Add missing scalars to client.const

### DIFF
--- a/client/constants.h
+++ b/client/constants.h
@@ -676,8 +676,8 @@ BETTER_ENUM(DamageType, int,
 constexpr int XYPixelsPerWalktile = 8;
 constexpr int XYPixelsPerBuildtile = 32;
 constexpr int XYWalktilesPerBuildtile = XYPixelsPerBuildtile / XYPixelsPerWalktile;
-constexpr double HitProbRangedUphilDoodad = 0.53125;
-constexpr double ProbRanged = 0.99609375;
+constexpr double HitProbRangedUphillDoodad = 0.53125;
+constexpr double HitProbRanged = 0.99609375;
 
 inline bool isBuilding(UnitType id) {
   return (

--- a/client/constants_lua.cpp
+++ b/client/constants_lua.cpp
@@ -15,6 +15,7 @@
 #include "lua_utils.h"
 
 using client::lua::pushValue;
+using client::lua::pushToTable;
 using client::lua::sealTable;
 
 namespace {
@@ -292,6 +293,13 @@ namespace client {
 void registerConstants(lua_State* L, int index) {
   lua_pushvalue(L, index);
   lua_newtable(L);
+
+  // Numeric constants
+  pushToTable(L, "xy_pixels_per_walktile", BW::XYPixelsPerWalktile);
+  pushToTable(L, "xy_pixels_per_buildtile", BW::XYPixelsPerBuildtile);
+  pushToTable(L, "xy_walktiles_per_buildtile", BW::XYWalktilesPerBuildtile);
+  pushToTable(L, "hit_prob_ranged_uphill_doodad", BW::HitProbRangedUphillDoodad);
+  pushToTable(L, "hit_prob_ranged", BW::HitProbRanged);
 
   pushTable<BW::Command>(L, fromCamelCaseToLower);
   lua_setfield(L, -2, "commands");

--- a/client/lua_utils.h
+++ b/client/lua_utils.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <string>
 #include <vector>
 
@@ -55,9 +56,11 @@ inline void pushValue(lua_State* L, const std::vector<T>& val) {
 }
 
 template <typename T>
-inline void pushToTable(lua_State* L, int index, const char* key, T val) {
+inline void pushToTable(lua_State* L, const char* key, T val) {
+  // Table is expected at top of stack
+  assert(lua_istable(L, -1));
   pushValue(L, val);
-  lua_setfield(L, index, key);
+  lua_setfield(L, -2, key);
 }
 
 } // namespace lua


### PR DESCRIPTION
A few scalar constants got lost in the transition to C++. They were declared in
constants.h but not added to the `client.const` Lua table.