### PR TITLE
Refactored C++ and Lua namespaces

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1,1 +1,0 @@
-return require('torchcraft.tc_lib').client

--- a/client/client.cpp
+++ b/client/client.cpp
@@ -20,7 +20,7 @@ namespace {
 
 void buildHandshakeMessage(
     flatbuffers::FlatBufferBuilder& fbb,
-    const client::Client::Options& opts) {
+    const torchcraft::Client::Options& opts) {
   torchcraft::fbs::HandshakeClientT hsc;
   hsc.protocol = 17;
   hsc.map = opts.initial_map;
@@ -42,7 +42,7 @@ void buildHandshakeMessage(
 
 void buildCommandMessage(
     flatbuffers::FlatBufferBuilder& fbb,
-    const std::vector<client::Client::Command>& commands) {
+    const std::vector<torchcraft::Client::Command>& commands) {
   std::vector<flatbuffers::Offset<torchcraft::fbs::Command>> offsets;
   for (auto comm : commands) {
     offsets.push_back(torchcraft::fbs::CreateCommandDirect(
@@ -57,10 +57,10 @@ void buildCommandMessage(
 
 } // namespace
 
-namespace client {
+namespace torchcraft {
 
 void init() {
-  client::BW::data::init();
+  torchcraft::BW::data::init();
 }
 
 //============================= LIFECYCLE ====================================
@@ -258,4 +258,4 @@ bool Client::receive(std::vector<std::string>& updates) {
   return true;
 }
 
-} // namespace client
+} // namespace torchcraft

--- a/client/connection.cpp
+++ b/client/connection.cpp
@@ -12,7 +12,7 @@
 
 #include "connection.h"
 
-namespace client {
+namespace torchcraft {
 
 /////////////////////////////// PUBLIC ///////////////////////////////////////
 
@@ -109,4 +109,4 @@ void Connection::clearError() {
   errmsg_.clear();
 }
 
-} // namespace client
+} // namespace torchcraft

--- a/client/connection.h
+++ b/client/connection.h
@@ -11,7 +11,7 @@
 
 #include "zmq.hpp"
 
-namespace client {
+namespace torchcraft {
 
 class Connection {
  public:
@@ -79,4 +79,4 @@ class Connection {
   std::string errmsg_;
 };
 
-} // namespace client
+} // namespace torchcraft

--- a/client/constants.cpp
+++ b/client/constants.cpp
@@ -14,27 +14,27 @@
 namespace {
 
 template <typename T>
-std::unordered_map<client::BW::UnitType, int> buildTotalPriceMap(const T& prices) {
-  std::unordered_map<client::BW::UnitType, int> total;
-  using client::BW::data::KeyIndex;
+std::unordered_map<torchcraft::BW::UnitType, int> buildTotalPriceMap(const T& prices) {
+  std::unordered_map<torchcraft::BW::UnitType, int> total;
+  using torchcraft::BW::data::KeyIndex;
 
   // Production prices for producers
-  for (auto ut : client::BW::UnitType::_values()) {
-    if (!client::BW::unitProductions(ut).empty()) {
+  for (auto ut : torchcraft::BW::UnitType::_values()) {
+    if (!torchcraft::BW::unitProductions(ut).empty()) {
       total[ut] = prices[KeyIndex.at(ut._to_string())];
     }
   }
 
   // Two separate loops required so that total prices are not overwritten
-  for (auto producer : client::BW::UnitType::_values()) {
-    for (auto ut : client::BW::unitProductions(producer)) {
+  for (auto producer : torchcraft::BW::UnitType::_values()) {
+    for (auto ut : torchcraft::BW::unitProductions(producer)) {
       int price;
-      if (client::BW::isBuilding(producer) ||
-          producer == +client::BW::UnitType::Zerg_Larva) {
+      if (torchcraft::BW::isBuilding(producer) ||
+          producer == +torchcraft::BW::UnitType::Zerg_Larva) {
         price = prices[KeyIndex.at(ut._to_string())];
       } else if (
-          ut == +client::BW::UnitType::Protoss_Archon ||
-          ut == +client::BW::UnitType::Protoss_Dark_Archon) {
+          ut == +torchcraft::BW::UnitType::Protoss_Archon ||
+          ut == +torchcraft::BW::UnitType::Protoss_Dark_Archon) {
         price = 2 * prices[KeyIndex.at(producer._to_string())];
       } else {
         price = prices[KeyIndex.at(producer._to_string())] +
@@ -49,7 +49,7 @@ std::unordered_map<client::BW::UnitType, int> buildTotalPriceMap(const T& prices
 
 } // namespace
 
-namespace client {
+namespace torchcraft {
 namespace BW {
 
 // Returns a sorted (by integral value) vector of units that a given unit is
@@ -361,4 +361,4 @@ void init() {
 
 } // namespace data
 } // namespace BW
-} // namespace client
+} // namespace torchcraft

--- a/client/constants_static.cpp
+++ b/client/constants_static.cpp
@@ -10,7 +10,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace client {
+namespace torchcraft {
 namespace BW {
 namespace data {
 

--- a/client/state.cpp
+++ b/client/state.cpp
@@ -11,7 +11,7 @@
 
 #include "BWEnv/fbs/messages_generated.h"
 
-namespace client {
+namespace torchcraft {
 
 State::State(bool microBattles, std::set<BW::UnitType> onlyConsiderTypes)
     : RefCounted(),
@@ -259,7 +259,7 @@ void State::postUpdate(std::vector<std::string>& upd) {
         fus.second.end(),
         std::back_inserter(units[player]),
         [this, player](const replayer::Unit& unit) {
-          auto ut = client::BW::UnitType::_from_integral_nothrow(unit.type);
+          auto ut = torchcraft::BW::UnitType::_from_integral_nothrow(unit.type);
           return (
               // Unit is of known type (or enemy unit)
               (player != player_id || ut) &&
@@ -327,4 +327,4 @@ bool State::checkBattleFinished(std::vector<std::string>& upd) {
   return false;
 }
 
-} // namespace client
+} // namespace torchcraft

--- a/include/client.h
+++ b/include/client.h
@@ -15,7 +15,7 @@
 
 #include "constants.h"
 
-namespace client {
+namespace torchcraft {
 
 void init();
 
@@ -121,4 +121,4 @@ class Client {
   std::string error_;
 };
 
-} // namespace client
+} // namespace torchcraft

--- a/include/constants.h
+++ b/include/constants.h
@@ -17,7 +17,7 @@
 #define BETTER_ENUMS_MACRO_FILE "enum_macros.h"
 #include "enum.h"
 
-namespace client {
+namespace torchcraft {
 namespace BW {
 
 BETTER_ENUM(
@@ -812,16 +812,16 @@ void init();
 } // namespace data
 
 } // namespace BW
-} // namespace client
+} // namespace torchcraft
 
 // Specialized hash functions for enums declared above
 namespace std {
 template <>
-struct hash<client::BW::UnitType> {
-  typedef client::BW::UnitType argument_type;
+struct hash<torchcraft::BW::UnitType> {
+  typedef torchcraft::BW::UnitType argument_type;
   typedef std::size_t result_type;
   result_type operator()(argument_type const& s) const {
-		return std::hash<client::BW::UnitType::_integral>{}(s._to_integral());
+		return std::hash<torchcraft::BW::UnitType::_integral>{}(s._to_integral());
   }
 };
 } // namespace std

--- a/include/frame.h
+++ b/include/frame.h
@@ -26,6 +26,7 @@ typedef int int32_t;
 
 //TODO Check types !
 
+namespace torchcraft {
 namespace replayer {
   struct Order {
     int32_t first_frame; // first frame number where order appeared
@@ -197,4 +198,5 @@ namespace replayer {
   };
   std::ostream& operator<<(std::ostream& out, const Frame& o);
   std::istream& operator>>(std::istream& in, Frame& o);
-} // replayer
+} // namespace replayer
+} // namespace torchcraft

--- a/include/state.h
+++ b/include/state.h
@@ -25,7 +25,7 @@ struct EndGame;
 }
 }
 
-namespace client {
+namespace torchcraft {
 
 class State : public RefCounted {
  public:
@@ -123,4 +123,4 @@ class State : public RefCounted {
   std::set<BW::UnitType> onlyConsiderTypes_;
 };
 
-} // namespace client
+} // namespace torchcraft

--- a/init.lua
+++ b/init.lua
@@ -1,15 +1,18 @@
 local torchcraft = require 'torchcraft._env'
 local utils = require 'torchcraft.utils'
 local replayer = require 'torchcraft.replayer'
-local client = require 'torchcraft.client'
 local tablex = require 'pl.tablex'
 local image = require 'image'
-
--- Pull constants into module namespace
-for k,v in pairs(client.const) do
+local lib = require 'torchcraft.tc_lib'
+for k,v in pairs(lib) do
     torchcraft[k] = v
 end
-for k,v in pairs(client.const.commands) do
+
+-- Pull constants into module namespace
+for k,v in pairs(lib.const) do
+    torchcraft[k] = v
+end
+for k,v in pairs(lib.const.commands) do
     torchcraft[k] = v
 end
 
@@ -27,7 +30,7 @@ assert(torchcraft.total_price.gas[torchcraft.unittypes.Terran_Science_Vessel]
 
 
 torchcraft.hostname = nil
-torchcraft.client = client.Client()
+torchcraft.client = torchcraft.Client()
 torchcraft.state = torchcraft.client.state
 torchcraft.DEBUG = 0
 torchcraft.initial_map = nil
@@ -168,7 +171,7 @@ function torchcraft.new()
    for k,v in pairs(torchcraft) do
       newtc[k] = v
    end
-   newtc.client = client.Client()
+   newtc.client = torchcraft.Client()
    newtc.state = newtc.client.state
    newtc.mode = tablex.deepcopy(torchcraft.mode)  -- reset mode for new context
    newtc:set_variables()

--- a/lua/client_lua.cpp
+++ b/lua/client_lua.cpp
@@ -19,14 +19,14 @@
 
 namespace {
 
-inline client::Client* checkClient(lua_State* L, int index = 1) {
+inline torchcraft::Client* checkClient(lua_State* L, int index = 1) {
   auto s = luaL_checkudata(L, index, "torchcraft.Client");
   luaL_argcheck(L, s != nullptr, index, "'client' expected");
-  return *static_cast<client::Client**>(s);
+  return *static_cast<torchcraft::Client**>(s);
 }
 
-client::Client::Command parseCommand(const std::string& str) {
-  client::Client::Command comm;
+torchcraft::Client::Command parseCommand(const std::string& str) {
+  torchcraft::Client::Command comm;
   bool gotCode = false;
   std::istringstream ss(str);
   for (std::string arg; std::getline(ss, arg, ',');) {
@@ -44,9 +44,9 @@ client::Client::Command parseCommand(const std::string& str) {
   return comm;
 }
 
-std::vector<client::Client::Command> parseCommandString(
+std::vector<torchcraft::Client::Command> parseCommandString(
     const std::string& str) {
-  std::vector<client::Client::Command> comms;
+  std::vector<torchcraft::Client::Command> comms;
   std::istringstream ss(str);
   for (std::string part; std::getline(ss, part, ':');) {
     comms.emplace_back(parseCommand(part));
@@ -57,7 +57,7 @@ std::vector<client::Client::Command> parseCommandString(
 } // namespace
 
 int newClient(lua_State* L) {
-  client::Client* cl = new client::Client();
+  torchcraft::Client* cl = new torchcraft::Client();
   luaT_pushudata(L, cl, "torchcraft.Client");
 
   // Store Lua wrapped state in uservalue table so that all changes done by Lua
@@ -77,7 +77,7 @@ int freeClient(lua_State* L) {
 
 int gcClient(lua_State* L) {
   auto cl =
-      static_cast<client::Client**>(luaL_checkudata(L, 1, "torchcraft.Client"));
+      static_cast<torchcraft::Client**>(luaL_checkudata(L, 1, "torchcraft.Client"));
   assert(*cl != nullptr);
   delete *cl;
   *cl = nullptr;
@@ -131,7 +131,7 @@ int closeClient(lua_State* L) {
 
 int initClient(lua_State* L) {
   auto cl = checkClient(L);
-  client::Client::Options opts;
+  torchcraft::Client::Options opts;
   if (lua_gettop(L) > 1) {
     if (!lua_istable(L, 2)) {
       return luaL_error(L, "table argument expected");
@@ -171,7 +171,7 @@ int initClient(lua_State* L) {
 
     lua_getfield(L, 2, "only_consider_types");
     if (!lua_isnil(L, -1)) {
-      opts.only_consider_types = client::getConsideredTypes(L);
+      opts.only_consider_types = torchcraft::getConsideredTypes(L);
     }
     lua_pop(L, 1);
   }
@@ -192,7 +192,7 @@ int initClient(lua_State* L) {
 
 int sendClient(lua_State* L) {
   auto cl = checkClient(L);
-  std::vector<client::Client::Command> comms;
+  std::vector<torchcraft::Client::Command> comms;
 
   if (lua_istable(L, 2)) {
     lua_pushvalue(L, 2);
@@ -231,7 +231,7 @@ int receiveClient(lua_State* L) {
   return 1;
 }
 
-namespace client {
+namespace torchcraft {
 void registerClient(lua_State* L, int index) {
   luaT_newlocalmetatable(
       L,

--- a/lua/client_lua.h
+++ b/lua/client_lua.h
@@ -39,6 +39,6 @@ const struct luaL_Reg client_m[] = {
 
 } // extern "C"
 
-namespace client {
+namespace torchcraft {
 void registerClient(lua_State* L, int index);
 }

--- a/lua/constants_lua.cpp
+++ b/lua/constants_lua.cpp
@@ -14,9 +14,9 @@
 #include "constants_lua.h"
 #include "lua_utils.h"
 
-using client::lua::pushValue;
-using client::lua::pushToTable;
-using client::lua::sealTable;
+using torchcraft::lua::pushValue;
+using torchcraft::lua::pushToTable;
+using torchcraft::lua::sealTable;
 
 namespace {
 
@@ -40,41 +40,41 @@ std::string fromCamelCaseToLower(const std::string& s) {
 
 int wisBuilding(lua_State* L) {
   int n = luaL_checkint(L, lua_gettop(L) > 1 ? 2 : 1);
-  auto id = client::BW::UnitType::_from_integral_nothrow(n);
+  auto id = torchcraft::BW::UnitType::_from_integral_nothrow(n);
   if (!id) {
     return luaL_error(L, "Invalid unit ID: %d", n);
   }
-  lua_pushboolean(L, client::BW::isBuilding(*id));
+  lua_pushboolean(L, torchcraft::BW::isBuilding(*id));
   return 1;
 }
 
 int wisWorker(lua_State* L) {
   int n = luaL_checkint(L, lua_gettop(L) > 1 ? 2 : 1);
-  auto id = client::BW::UnitType::_from_integral_nothrow(n);
+  auto id = torchcraft::BW::UnitType::_from_integral_nothrow(n);
   if (!id) {
     return luaL_error(L, "Invalid unit ID: %d", n);
   }
-  lua_pushboolean(L, client::BW::isWorker(*id));
+  lua_pushboolean(L, torchcraft::BW::isWorker(*id));
   return 1;
 }
 
 int wisMineralField(lua_State* L) {
   int n = luaL_checkint(L, lua_gettop(L) > 1 ? 2 : 1);
-  auto id = client::BW::UnitType::_from_integral_nothrow(n);
+  auto id = torchcraft::BW::UnitType::_from_integral_nothrow(n);
   if (!id) {
     return luaL_error(L, "Invalid unit ID: %d", n);
   }
-  lua_pushboolean(L, client::BW::isMineralField(*id));
+  lua_pushboolean(L, torchcraft::BW::isMineralField(*id));
   return 1;
 }
 
 int wisGasGeyser(lua_State* L) {
   int n = luaL_checkint(L, lua_gettop(L) > 1 ? 2 : 1);
-  auto id = client::BW::UnitType::_from_integral_nothrow(n);
+  auto id = torchcraft::BW::UnitType::_from_integral_nothrow(n);
   if (!id) {
     return luaL_error(L, "Invalid unit ID: %d", n);
   }
-  lua_pushboolean(L, client::BW::isGasGeyser(*id));
+  lua_pushboolean(L, torchcraft::BW::isGasGeyser(*id));
   return 1;
 }
 
@@ -116,12 +116,12 @@ void pushVector(lua_State* L, std::vector<Enum> v) {
 template <typename T>
 void pushStaticValues(lua_State* L, const T m[]) {
   lua_newtable(L);
-  for (size_t i = 0; i < client::BW::data::NumKeys; i++) {
-    const auto& key = client::BW::data::Keys[i];
+  for (size_t i = 0; i < torchcraft::BW::data::NumKeys; i++) {
+    const auto& key = torchcraft::BW::data::Keys[i];
     pushValue(L, m[i]);
     lua_setfield(L, -2, key.c_str());
 
-    auto t = client::BW::UnitType::_from_string_nothrow(key.c_str());
+    auto t = torchcraft::BW::UnitType::_from_string_nothrow(key.c_str());
     if (t) {
       pushValue(L, m[i]);
       lua_rawseti(L, -2, t->_to_integral());
@@ -130,7 +130,7 @@ void pushStaticValues(lua_State* L, const T m[]) {
   sealTable(L);
 }
 
-void pushMap(lua_State* L, std::unordered_map<client::BW::UnitType, int>& m) {
+void pushMap(lua_State* L, std::unordered_map<torchcraft::BW::UnitType, int>& m) {
   lua_newtable(L);
   for (const auto& kv : m) {
     pushValue(L, kv.second);
@@ -141,155 +141,155 @@ void pushMap(lua_State* L, std::unordered_map<client::BW::UnitType, int>& m) {
 
 void pushStaticData(lua_State* L) {
   lua_newtable(L);
-  pushStaticValues(L, client::BW::data::CanAttack);
+  pushStaticValues(L, torchcraft::BW::data::CanAttack);
   lua_setfield(L, -2, "canAttack");
-  pushStaticValues(L, client::BW::data::DimensionRight);
+  pushStaticValues(L, torchcraft::BW::data::DimensionRight);
   lua_setfield(L, -2, "dimensionRight");
-  pushStaticValues(L, client::BW::data::Height);
+  pushStaticValues(L, torchcraft::BW::data::Height);
   lua_setfield(L, -2, "height");
-  pushStaticValues(L, client::BW::data::IsMineralField);
+  pushStaticValues(L, torchcraft::BW::data::IsMineralField);
   lua_setfield(L, -2, "isMineralField");
-  pushStaticValues(L, client::BW::data::CanProduce);
+  pushStaticValues(L, torchcraft::BW::data::CanProduce);
   lua_setfield(L, -2, "canProduce");
-  pushStaticValues(L, client::BW::data::IsRefinery);
+  pushStaticValues(L, torchcraft::BW::data::IsRefinery);
   lua_setfield(L, -2, "isRefinery");
-  pushStaticValues(L, client::BW::data::IsResourceDepot);
+  pushStaticValues(L, torchcraft::BW::data::IsResourceDepot);
   lua_setfield(L, -2, "isResourceDepot");
-  pushStaticValues(L, client::BW::data::RegeneratesHP);
+  pushStaticValues(L, torchcraft::BW::data::RegeneratesHP);
   lua_setfield(L, -2, "regeneratesHP");
-  pushStaticValues(L, client::BW::data::IsCloakable);
+  pushStaticValues(L, torchcraft::BW::data::IsCloakable);
   lua_setfield(L, -2, "isCloakable");
-  pushStaticValues(L, client::BW::data::IsTwoUnitsInOneEgg);
+  pushStaticValues(L, torchcraft::BW::data::IsTwoUnitsInOneEgg);
   lua_setfield(L, -2, "isTwoUnitsInOneEgg");
-  pushStaticValues(L, client::BW::data::IsSpellcaster);
+  pushStaticValues(L, torchcraft::BW::data::IsSpellcaster);
   lua_setfield(L, -2, "isSpellcaster");
-  pushStaticValues(L, client::BW::data::SupplyRequired);
+  pushStaticValues(L, torchcraft::BW::data::SupplyRequired);
   lua_setfield(L, -2, "supplyRequired");
-  pushStaticValues(L, client::BW::data::AirWeapon);
+  pushStaticValues(L, torchcraft::BW::data::AirWeapon);
   lua_setfield(L, -2, "airWeapon");
-  pushStaticValues(L, client::BW::data::BuildScore);
+  pushStaticValues(L, torchcraft::BW::data::BuildScore);
   lua_setfield(L, -2, "buildScore");
-  pushStaticValues(L, client::BW::data::MaxAirHits);
+  pushStaticValues(L, torchcraft::BW::data::MaxAirHits);
   lua_setfield(L, -2, "maxAirHits");
-  pushStaticValues(L, client::BW::data::IsPowerup);
+  pushStaticValues(L, torchcraft::BW::data::IsPowerup);
   lua_setfield(L, -2, "isPowerup");
-  pushStaticValues(L, client::BW::data::IsBeacon);
+  pushStaticValues(L, torchcraft::BW::data::IsBeacon);
   lua_setfield(L, -2, "isBeacon");
-  pushStaticValues(L, client::BW::data::MineralPrice);
+  pushStaticValues(L, torchcraft::BW::data::MineralPrice);
   lua_setfield(L, -2, "mineralPrice");
-  pushStaticValues(L, client::BW::data::IsInvincible);
+  pushStaticValues(L, torchcraft::BW::data::IsInvincible);
   lua_setfield(L, -2, "isInvincible");
-  pushStaticValues(L, client::BW::data::RequiredTech);
+  pushStaticValues(L, torchcraft::BW::data::RequiredTech);
   lua_setfield(L, -2, "requiredTech");
-  pushStaticValues(L, client::BW::data::DimensionDown);
+  pushStaticValues(L, torchcraft::BW::data::DimensionDown);
   lua_setfield(L, -2, "dimensionDown");
-  pushStaticValues(L, client::BW::data::CanBuildAddon);
+  pushStaticValues(L, torchcraft::BW::data::CanBuildAddon);
   lua_setfield(L, -2, "canBuildAddon");
-  pushStaticValues(L, client::BW::data::DimensionLeft);
+  pushStaticValues(L, torchcraft::BW::data::DimensionLeft);
   lua_setfield(L, -2, "dimensionLeft");
-  pushStaticValues(L, client::BW::data::ProducesLarva);
+  pushStaticValues(L, torchcraft::BW::data::ProducesLarva);
   lua_setfield(L, -2, "producesLarva");
-  pushStaticValues(L, client::BW::data::Armor);
+  pushStaticValues(L, torchcraft::BW::data::Armor);
   lua_setfield(L, -2, "armor");
-  pushStaticValues(L, client::BW::data::IsMechanical);
+  pushStaticValues(L, torchcraft::BW::data::IsMechanical);
   lua_setfield(L, -2, "isMechanical");
-  pushStaticValues(L, client::BW::data::IsBuilding);
+  pushStaticValues(L, torchcraft::BW::data::IsBuilding);
   lua_setfield(L, -2, "isBuilding");
-  pushStaticValues(L, client::BW::data::SupplyProvided);
+  pushStaticValues(L, torchcraft::BW::data::SupplyProvided);
   lua_setfield(L, -2, "supplyProvided");
-  pushStaticValues(L, client::BW::data::SightRange);
+  pushStaticValues(L, torchcraft::BW::data::SightRange);
   lua_setfield(L, -2, "sightRange");
-  pushStaticValues(L, client::BW::data::GasPrice);
+  pushStaticValues(L, torchcraft::BW::data::GasPrice);
   lua_setfield(L, -2, "gasPrice");
-  pushStaticValues(L, client::BW::data::MaxHitPoints);
+  pushStaticValues(L, torchcraft::BW::data::MaxHitPoints);
   lua_setfield(L, -2, "maxHitPoints");
-  pushStaticValues(L, client::BW::data::Width);
+  pushStaticValues(L, torchcraft::BW::data::Width);
   lua_setfield(L, -2, "width");
-  pushStaticValues(L, client::BW::data::TileWidth);
+  pushStaticValues(L, torchcraft::BW::data::TileWidth);
   lua_setfield(L, -2, "tileWidth");
-  pushStaticValues(L, client::BW::data::IsHero);
+  pushStaticValues(L, torchcraft::BW::data::IsHero);
   lua_setfield(L, -2, "isHero");
-  pushStaticValues(L, client::BW::data::SeekRange);
+  pushStaticValues(L, torchcraft::BW::data::SeekRange);
   lua_setfield(L, -2, "seekRange");
-  pushStaticValues(L, client::BW::data::BuildTime);
+  pushStaticValues(L, torchcraft::BW::data::BuildTime);
   lua_setfield(L, -2, "buildTime");
-  pushStaticValues(L, client::BW::data::IsCritter);
+  pushStaticValues(L, torchcraft::BW::data::IsCritter);
   lua_setfield(L, -2, "isCritter");
-  pushStaticValues(L, client::BW::data::RequiresPsi);
+  pushStaticValues(L, torchcraft::BW::data::RequiresPsi);
   lua_setfield(L, -2, "requiresPsi");
-  pushStaticValues(L, client::BW::data::IsSpecialBuilding);
+  pushStaticValues(L, torchcraft::BW::data::IsSpecialBuilding);
   lua_setfield(L, -2, "isSpecialBuilding");
-  pushStaticValues(L, client::BW::data::GroundWeapon);
+  pushStaticValues(L, torchcraft::BW::data::GroundWeapon);
   lua_setfield(L, -2, "groundWeapon");
-  pushStaticValues(L, client::BW::data::IsFlyer);
+  pushStaticValues(L, torchcraft::BW::data::IsFlyer);
   lua_setfield(L, -2, "isFlyer");
-  pushStaticValues(L, client::BW::data::Size);
+  pushStaticValues(L, torchcraft::BW::data::Size);
   lua_setfield(L, -2, "size");
-  pushStaticValues(L, client::BW::data::IsNeutral);
+  pushStaticValues(L, torchcraft::BW::data::IsNeutral);
   lua_setfield(L, -2, "isNeutral");
-  pushStaticValues(L, client::BW::data::MaxShields);
+  pushStaticValues(L, torchcraft::BW::data::MaxShields);
   lua_setfield(L, -2, "maxShields");
-  pushStaticValues(L, client::BW::data::HasPermanentCloak);
+  pushStaticValues(L, torchcraft::BW::data::HasPermanentCloak);
   lua_setfield(L, -2, "hasPermanentCloak");
-  pushStaticValues(L, client::BW::data::TopSpeed);
+  pushStaticValues(L, torchcraft::BW::data::TopSpeed);
   lua_setfield(L, -2, "topSpeed");
-  pushStaticValues(L, client::BW::data::TileHeight);
+  pushStaticValues(L, torchcraft::BW::data::TileHeight);
   lua_setfield(L, -2, "tileHeight");
-  pushStaticValues(L, client::BW::data::IsRobotic);
+  pushStaticValues(L, torchcraft::BW::data::IsRobotic);
   lua_setfield(L, -2, "isRobotic");
-  pushStaticValues(L, client::BW::data::DimensionUp);
+  pushStaticValues(L, torchcraft::BW::data::DimensionUp);
   lua_setfield(L, -2, "dimensionUp");
-  pushStaticValues(L, client::BW::data::DestroyScore);
+  pushStaticValues(L, torchcraft::BW::data::DestroyScore);
   lua_setfield(L, -2, "destroyScore");
-  pushStaticValues(L, client::BW::data::SpaceProvided);
+  pushStaticValues(L, torchcraft::BW::data::SpaceProvided);
   lua_setfield(L, -2, "spaceProvided");
-  pushStaticValues(L, client::BW::data::TileSize);
+  pushStaticValues(L, torchcraft::BW::data::TileSize);
   lua_setfield(L, -2, "tileSize");
-  pushStaticValues(L, client::BW::data::HaltDistance);
+  pushStaticValues(L, torchcraft::BW::data::HaltDistance);
   lua_setfield(L, -2, "haltDistance");
-  pushStaticValues(L, client::BW::data::IsAddon);
+  pushStaticValues(L, torchcraft::BW::data::IsAddon);
   lua_setfield(L, -2, "isAddon");
-  pushStaticValues(L, client::BW::data::CanMove);
+  pushStaticValues(L, torchcraft::BW::data::CanMove);
   lua_setfield(L, -2, "canMove");
-  pushStaticValues(L, client::BW::data::IsFlyingBuilding);
+  pushStaticValues(L, torchcraft::BW::data::IsFlyingBuilding);
   lua_setfield(L, -2, "isFlyingBuilding");
-  pushStaticValues(L, client::BW::data::MaxEnergy);
+  pushStaticValues(L, torchcraft::BW::data::MaxEnergy);
   lua_setfield(L, -2, "maxEnergy");
-  pushStaticValues(L, client::BW::data::IsDetector);
+  pushStaticValues(L, torchcraft::BW::data::IsDetector);
   lua_setfield(L, -2, "isDetector");
-  pushStaticValues(L, client::BW::data::IsOrganic);
+  pushStaticValues(L, torchcraft::BW::data::IsOrganic);
   lua_setfield(L, -2, "isOrganic");
-  pushStaticValues(L, client::BW::data::SpaceRequired);
+  pushStaticValues(L, torchcraft::BW::data::SpaceRequired);
   lua_setfield(L, -2, "spaceRequired");
-  pushStaticValues(L, client::BW::data::IsFlagBeacon);
+  pushStaticValues(L, torchcraft::BW::data::IsFlagBeacon);
   lua_setfield(L, -2, "isFlagBeacon");
-  pushStaticValues(L, client::BW::data::IsWorker);
+  pushStaticValues(L, torchcraft::BW::data::IsWorker);
   lua_setfield(L, -2, "isWorker");
-  pushStaticValues(L, client::BW::data::IsBurrowable);
+  pushStaticValues(L, torchcraft::BW::data::IsBurrowable);
   lua_setfield(L, -2, "isBurrowable");
-  pushStaticValues(L, client::BW::data::CloakingTech);
+  pushStaticValues(L, torchcraft::BW::data::CloakingTech);
   lua_setfield(L, -2, "cloakingTech");
-  pushStaticValues(L, client::BW::data::IsResourceContainer);
+  pushStaticValues(L, torchcraft::BW::data::IsResourceContainer);
   lua_setfield(L, -2, "isResourceContainer");
-  pushStaticValues(L, client::BW::data::Acceleration);
+  pushStaticValues(L, torchcraft::BW::data::Acceleration);
   lua_setfield(L, -2, "acceleration");
-  pushStaticValues(L, client::BW::data::IsSpell);
+  pushStaticValues(L, torchcraft::BW::data::IsSpell);
   lua_setfield(L, -2, "isSpell");
-  pushStaticValues(L, client::BW::data::RequiresCreep);
+  pushStaticValues(L, torchcraft::BW::data::RequiresCreep);
   lua_setfield(L, -2, "requiresCreep");
-  pushStaticValues(L, client::BW::data::ArmorUpgrade);
+  pushStaticValues(L, torchcraft::BW::data::ArmorUpgrade);
   lua_setfield(L, -2, "armorUpgrade");
-  pushStaticValues(L, client::BW::data::MaxGroundHits);
+  pushStaticValues(L, torchcraft::BW::data::MaxGroundHits);
   lua_setfield(L, -2, "maxGroundHits");
-  pushStaticValues(L, client::BW::data::TurnRadius);
+  pushStaticValues(L, torchcraft::BW::data::TurnRadius);
   lua_setfield(L, -2, "turnRadius");
-  pushStaticValues(L, client::BW::data::GetRace);
+  pushStaticValues(L, torchcraft::BW::data::GetRace);
   lua_setfield(L, -2, "getRace");
 }
 
 } // namespace
 
-namespace client {
+namespace torchcraft {
 void registerConstants(lua_State* L, int index) {
   lua_pushvalue(L, index);
   lua_newtable(L);
@@ -388,13 +388,13 @@ void registerConstants(lua_State* L, int index) {
 
   // total_price
   lua_newtable(L);
-  pushMap(L, client::BW::data::TotalMineralPrice);
+  pushMap(L, torchcraft::BW::data::TotalMineralPrice);
   lua_setfield(L, -2, "mineral");
-  pushMap(L, client::BW::data::TotalGasPrice);
+  pushMap(L, torchcraft::BW::data::TotalGasPrice);
   lua_setfield(L, -2, "gas");
   lua_setfield(L, -2, "total_price");
 
   lua_setfield(L, -2, "const");
   lua_pop(L, 1);
 }
-} // namespace client
+} // namespace torchcraft

--- a/lua/constants_lua.h
+++ b/lua/constants_lua.h
@@ -16,6 +16,6 @@ extern "C" {
 
 }
 
-namespace client {
+namespace torchcraft {
 void registerConstants(lua_State* L, int index);
 }

--- a/lua/frame_lua.cpp
+++ b/lua/frame_lua.cpp
@@ -9,8 +9,8 @@
 
 #include "frame_lua.h"
 
-using namespace replayer;
 using namespace std;
+using namespace torchcraft::replayer;
 
 // Utility
 
@@ -36,7 +36,7 @@ extern "C" int frameFromTable(lua_State* L) {
   Frame *f = new Frame();
   toFrame(L, 1, *f);
 
-  auto f2 = (replayer::Frame **)lua_newuserdata(L, sizeof(replayer::Frame *));
+  auto f2 = (Frame **)lua_newuserdata(L, sizeof(Frame *));
   *f2 = f;
 
   luaL_getmetatable(L, "torchcraft.Frame");

--- a/lua/frame_lua.h
+++ b/lua/frame_lua.h
@@ -21,7 +21,7 @@ extern "C" {
 
 #include "frame.h"
 
-replayer::Frame* checkFrame(lua_State* L, int id = 1);
+torchcraft::replayer::Frame* checkFrame(lua_State* L, int id = 1);
 
 extern "C" int frameFromTable(lua_State* L);
 extern "C" int frameFromString(lua_State* L);
@@ -41,11 +41,11 @@ void setBool(lua_State* L, const char* key, bool v);
 bool getField(lua_State* L, const char* key);
 int getInt(lua_State* L, const char* key);
 bool getBool(lua_State* L, const char* key);
-void pushUnit(lua_State* L, const replayer::Unit& unit);
+void pushUnit(lua_State* L, const torchcraft::replayer::Unit& unit);
 
 // Lua tables from/to Frame class
-void toFrame(lua_State* L, int id, replayer::Frame& res);
-void pushFrame(lua_State* L, const replayer::Frame& res);
+void toFrame(lua_State* L, int id, torchcraft::replayer::Frame& res);
+void pushFrame(lua_State* L, const torchcraft::replayer::Frame& res);
 
 const struct luaL_Reg frame_m [] = {
   {"__gc", gcFrame},

--- a/lua/gamestore.cpp
+++ b/lua/gamestore.cpp
@@ -10,7 +10,9 @@
 #include "gamestore.h"
 
 using namespace std;
-using namespace replayer;
+namespace replayer = torchcraft::replayer;
+using replayer::GameStore;
+using replayer::Replayer;
 
 // Serialization
 

--- a/lua/gamestore.h
+++ b/lua/gamestore.h
@@ -20,6 +20,7 @@
 #include "frame.h"
 #include "replayer.h"
 
+namespace torchcraft {
 namespace replayer {
 
   // When playing the game, we add frames to a Replayer.
@@ -156,9 +157,10 @@ namespace replayer {
   };
 
 
-} // replayer
+} // namespace replayer
+} // namespace torchcraft
 
-replayer::GameStore* checkGameStore(lua_State* L, int id = 1);
+torchcraft::replayer::GameStore* checkGameStore(lua_State* L, int id = 1);
 
 extern "C" int newGameStore(lua_State* L);
 extern "C" int gcGameStore(lua_State* L);

--- a/lua/init.cpp
+++ b/lua/init.cpp
@@ -26,7 +26,7 @@ extern "C" {
 #include "replayer.h"
 #include "state_lua.h"
 
-using namespace replayer;
+using torchcraft::replayer::GameStore;
 
 
 extern "C" int new_gameStore(lua_State* L) {
@@ -93,12 +93,12 @@ int registerReplayer(lua_State *L) {
 }
 
 int registerClient(lua_State* L) {
-  client::init();
+  torchcraft::init();
 
   lua_newtable(L);
-  client::registerClient(L, lua_gettop(L));
-  client::registerState(L, lua_gettop(L));
-  client::registerConstants(L, lua_gettop(L));
+  torchcraft::registerClient(L, lua_gettop(L));
+  torchcraft::registerState(L, lua_gettop(L));
+  torchcraft::registerConstants(L, lua_gettop(L));
   return 1;
 }
 
@@ -109,9 +109,7 @@ int registerClient(lua_State* L) {
  * all the c++ function for call from lua
  */
 extern "C" int luaopen_torchcraft_tc_lib(lua_State* L) {
-  lua_newtable(L);
   registerClient(L);
-  lua_setfield(L, -2, "client");
   registerReplayer(L);
   lua_setfield(L, -2, "replayer");
   return 1;

--- a/lua/lua_utils.cpp
+++ b/lua/lua_utils.cpp
@@ -13,7 +13,7 @@ extern "C" {
 
 #include "lua_utils.h"
 
-namespace client {
+namespace torchcraft {
 namespace lua {
 
 int sealedTableGuard(lua_State* L) {
@@ -31,4 +31,4 @@ void sealTable(lua_State* L, int index) {
 }
 
 } // namespace lua
-} // namespace client
+} // namespace torchcraft

--- a/lua/lua_utils.h
+++ b/lua/lua_utils.h
@@ -22,7 +22,7 @@ extern "C" {
 
 } // extern "C"
 
-namespace client {
+namespace torchcraft {
 namespace lua {
 
 void sealTable(lua_State* L, int index = -1);
@@ -64,4 +64,4 @@ inline void pushToTable(lua_State* L, const char* key, T val) {
 }
 
 } // namespace lua
-} // namespace client
+} // namespace torchcraft

--- a/lua/replayer.cpp
+++ b/lua/replayer.cpp
@@ -12,7 +12,8 @@
 #include "frame_lua.h"
 
 using namespace std;
-using namespace replayer;
+namespace replayer = torchcraft::replayer;
+using replayer::Replayer;
 
 // Serialization
 

--- a/lua/replayer.h
+++ b/lua/replayer.h
@@ -25,6 +25,7 @@ extern "C" {
 #include "refcount.h"
 #include "frame.h"
 
+namespace torchcraft {
 namespace replayer {
 
   struct Map{
@@ -105,9 +106,10 @@ namespace replayer {
       friend std::istream& operator>>(std::istream& in, Replayer& o);
   };
 
-} // replayer
+} // namespace replayer
+} // namespace torchcraft
 
-replayer::Replayer* checkReplayer(lua_State* L, int id = 1);
+torchcraft::replayer::Replayer* checkReplayer(lua_State* L, int id = 1);
 
 extern "C" int newReplayer(lua_State* L);
 extern "C" int gcReplayer(lua_State* L);

--- a/lua/state_lua.h
+++ b/lua/state_lua.h
@@ -17,7 +17,7 @@ extern "C" {
 #include <lua.h>
 
 int newState(lua_State* L);
-int pushState(lua_State* L, client::State* s = nullptr);
+int pushState(lua_State* L, torchcraft::State* s = nullptr);
 int freeState(lua_State* L);
 int gcState(lua_State* L);
 int indexState(lua_State* L);
@@ -42,8 +42,8 @@ const struct luaL_Reg state_m[] = {
 
 } // extern "C"
 
-namespace client {
-std::set<client::BW::UnitType> getConsideredTypes(lua_State* L, int index = -1);
+namespace torchcraft {
+std::set<torchcraft::BW::UnitType> getConsideredTypes(lua_State* L, int index = -1);
 
 void registerState(lua_State* L, int index);
 }

--- a/replayer/frame.cpp
+++ b/replayer/frame.cpp
@@ -9,6 +9,8 @@
 
 #include "frame.h"
 
+namespace replayer = torchcraft::replayer;
+
 std::ostream& replayer::operator<<(std::ostream& out, const replayer::Unit& o) {
   out << o.id << " " << o.x << " " << o.y << " "
     << o.health << " " << o.max_health << " "


### PR DESCRIPTION
C++ side: `client` is now `torchcraft`, and `replayer` resides in
`torchcraft::replayer`

Lua side: `torchcraft.client` is gone and the corresponding definitions have
moved to the top-level `torchcraft` module (this is done in `init.lua`).
`torchcraft.replayer` is available just like before. Importing the C++ module
will now return a table with definitions designated to the top-level module as
well as a sub-table for `replayer`.