### PR TITLE
Add sender uid field to flatbuffer message

### DIFF
--- a/BWEnv/fbs/messages.fbs
+++ b/BWEnv/fbs/messages.fbs
@@ -86,6 +86,7 @@ union Any {
 
 table Message {
   msg:Any;
+  uid:string; // sender ID
 }
 
 root_type Message;

--- a/client/client.cpp
+++ b/client/client.cpp
@@ -20,12 +20,7 @@
 namespace {
 
 std::string makeUid(size_t len = 6) {
-  static std::mt19937* rng = nullptr;
-  // Initialize random number generator
-  if (rng == nullptr) {
-    std::random_device rd;
-    rng = new std::mt19937(rd());
-  }
+  static std::mt19937 rng = std::mt19937(std::random_device()());
 
   static const char alphanum[] =
       "0123456789"
@@ -34,7 +29,7 @@ std::string makeUid(size_t len = 6) {
   std::uniform_int_distribution<int> dis(0, sizeof(alphanum) - 1);
   std::string s(len, 0);
   for (size_t i = 0; i < len; i++) {
-    s[i] = alphanum[dis(*rng)];
+    s[i] = alphanum[dis(rng)];
   }
   return s;
 }

--- a/client/client.cpp
+++ b/client/client.cpp
@@ -23,18 +23,18 @@ std::string makeUid(size_t len = 6) {
   static std::mt19937* rng = nullptr;
   // Initialize random number generator
   if (rng == nullptr) {
-    std::random_device r;
-    std::seed_seq seed{r(), r(), r(), r(), r(), r(), r(), r()};
-    rng = new std::mt19937(seed);
+    std::random_device rd;
+    rng = new std::mt19937(rd());
   }
 
   static const char alphanum[] =
       "0123456789"
       "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
       "abcdefghijklmnopqrstuvwxyz";
+  std::uniform_int_distribution<int> dis(0, sizeof(alphanum) - 1);
   std::string s(len, 0);
   for (size_t i = 0; i < len; i++) {
-    s[i] = alphanum[(*rng)() % (sizeof(alphanum) - 1)];
+    s[i] = alphanum[dis(*rng)];
   }
   return s;
 }

--- a/include/client.h
+++ b/include/client.h
@@ -119,6 +119,7 @@ class Client {
   State* state_;
   bool sent_;
   std::string error_;
+  std::string uid_;
 };
 
 } // namespace torchcraft


### PR DESCRIPTION
The purpose of this field is to make it easy to extend client-server
communication with custom scripts. For example, a client-side ID enables
association of REQ messages with a specific session. It is currently used by the
client only (on a per-connection basis) and ignored by the server.