### PR TITLE
Fixing set_map and overwriteConfig

### DIFF
--- a/BWEnv/src/controller.cc
+++ b/BWEnv/src/controller.cc
@@ -221,8 +221,8 @@ void Controller::setupHandshake()
 void Controller::handleCommand(int command, const std::vector<int>& args,
   const std::string& str)
 {
-  auto check_args = [&](uint32_t n) {
-    if (args.size() < n) throw(std::runtime_error("Not enough arguments."));
+  auto check_args = [&](int command, uint32_t n) {
+    if (args.size() < n) throw(std::runtime_error("Not enough arguments for command " + std::to_string(command)));
   };
   auto check_unit = [&](int id) {
     auto res = BWAPI::Broodwar->getUnit(id);
@@ -263,7 +263,7 @@ void Controller::handleCommand(int command, const std::vector<int>& args,
   }
   else if (command <= Commands::SET_MULTI)
   {
-    check_args(1);
+    check_args(command, 1);
     switch (command) {
     case Commands::SET_SPEED:
       Utils::bwlog(output_log, "Set game speed: %d", args[0]);
@@ -303,7 +303,7 @@ void Controller::handleCommand(int command, const std::vector<int>& args,
   }
   else if (command <= Commands::COMMAND_UNIT_PROTECTED)
   {
-    check_args(2);
+    check_args(command, 2);
     auto unit = check_unit(args[0]);
     auto cmd_type = args[1];
     auto target = (args.size() >= 3 ? BWAPI::Broodwar->getUnit(args[2]) : nullptr);

--- a/BWEnv/src/utils.cc
+++ b/BWEnv/src/utils.cc
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <fstream>
 #include <codecvt>
+#include <regex>
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
@@ -124,12 +125,13 @@ void Utils::overwriteConfig(const std::wstring& sc_path_,
   std::ifstream ini(path);
 
   std::string line;
+  std::regex regex("\\s*" + prefix + "\\s*=.*");
 
   bool found = false;
 
   while (getline(ini, line))
   {
-    if (!line.compare(0, prefix.size(), prefix)){
+    if (std::regex_match(line, regex)) {
       filedata.push_back(prefix + " = " + arg);
       found = true;
     }

--- a/lua/client_lua.cpp
+++ b/lua/client_lua.cpp
@@ -37,6 +37,7 @@ torchcraft::Client::Command parseCommand(const std::string& str) {
       try {
         comm.args.push_back(std::stoi(arg));
       } catch (std::invalid_argument& e) {
+        comm.args.push_back(-1);
         comm.str = arg;
       }
     }


### PR DESCRIPTION
This commit fixes https://github.com/TorchCraft/TorchCraft/issues/34 plus set_map not working anymore due to the flatbuffer commit. Tested on simple_dll.lua, and checked that `mapiteration=RANDOM` was not overwritten by set_map.