### PR TITLE
Basic drawing commands

### DIFF
--- a/BWEnv/include/controller.h
+++ b/BWEnv/include/controller.h
@@ -36,6 +36,12 @@ enum Commands {
   COMMAND_UNIT, COMMAND_UNIT_PROTECTED,
   // variable arguments
   COMMAND_USER,
+  // BAWPI drawing routins
+  DRAW_LINE,          // x1, y1, x2, y2, color
+  DRAW_UNIT_LINE,     // uid1, uid2, color
+  DRAW_UNIT_POS_LINE, // uid. x2, y2, color
+  DRAW_CIRCLE,        // x, y, radius, color
+  DRAW_UNIT_CIRCLE,   // uid, radiu, color
   // last command id
   COMMAND_END
 };
@@ -59,6 +65,7 @@ public:
   void endGame();
   void gameCleanUp();
   void clearLastFrame();
+  void executeDrawCommands();
   void onFrame();
   void packBullets(replayer::Frame& f);
   void packResources(replayer::Frame& f, BWAPI::PlayerInterface* player);
@@ -94,6 +101,7 @@ private:
   bool too_long_play_ = false;
   bool exit_process_ = false;
   bool with_image_ = false;
+  std::vector<std::vector<int>> draw_cmds_;
   torchcraft::fbs::FrameT tcframe_;
 };
 

--- a/include/constants.h
+++ b/include/constants.h
@@ -57,7 +57,14 @@ BETTER_ENUM(
     // For documentation about args, see usercommandtypes
     CommandUser = 16,
 
-    MAX = 17)
+    // BWAPI drawing routines
+    DrawLine = 17, //  x1, y1, x2, y2, color index
+    DrawUnitLine = 18, // uid1, uid2, color index
+    DrawUnitPosLine = 19, // uid, x2, y2, color index
+    DrawCircle = 20, //  x, y, radius, color index
+    DrawUnitCircle = 21, // uid, radius, color index
+
+    MAX = 22)
 
 BETTER_ENUM(
     UserCommandType,
@@ -72,7 +79,7 @@ BETTER_ENUM(
     Move_Screen_To_Pos = 4, // arguments: (x, y)
     Right_Click = 5, // arguments: (x, y)
 
-    USER_COMMAND_END = 7)
+    USER_COMMAND_END = 6)
 
 BETTER_ENUM(
     UnitCommandType,
@@ -674,6 +681,22 @@ BETTER_ENUM(
     Normal = 3,
     Ignore_Armor = 4,
     None = 5)
+
+BETTER_ENUM(
+    Color,
+    int,
+    Black = 0,
+    Brown = 19,
+    Grey = 74,
+    Red = 111,
+    Green = 117,
+    Cyan = 128,
+    Yellow = 135,
+    Teal = 159,
+    Purple = 164,
+    Blue = 165,
+    Orange = -179,
+    White = 255)
 
 constexpr int XYPixelsPerWalktile = 8;
 constexpr int XYPixelsPerBuildtile = 32;

--- a/lua/constants_lua.cpp
+++ b/lua/constants_lua.cpp
@@ -324,6 +324,8 @@ void registerConstants(lua_State* L, int index) {
   lua_setfield(L, -2, "unitsizes");
   pushTable<BW::DamageType>(L);
   lua_setfield(L, -2, "dmgtypes");
+  pushTable<BW::Color>(L);
+  lua_setfield(L, -2, "colors");
 
   lua_newtable(L);
   for (auto t : BW::UnitType::_values()) {


### PR DESCRIPTION
This adds a few basic commands that map to BWAPI's draw* functions for easy
client-side visualizations. Drawing commands are buffered in the controller,
executed at each frame and cleared before new client commands are being
received. For convenience, a few basic color values from StarCraft's palette
have been added to constants.h (taken from BWAPILIB/Source/Color.cpp).