### PR TITLE
Expose poll() in Client

### DIFF
--- a/client/client.cpp
+++ b/client/client.cpp
@@ -283,4 +283,22 @@ bool Client::receive(std::vector<std::string>& updates) {
   return true;
 }
 
+bool Client::poll(long timeout) {
+  clearError();
+  if (!conn_) {
+    error_ = "No active connection";
+    return false;
+  }
+
+  if (!conn_->poll(timeout)) {
+    std::stringstream ss;
+    ss << "Error during poll: " << conn_->errmsg() << " ("
+       << conn_->errnum() << ")";
+    error_ = ss.str();
+    return false;
+  }
+
+  return true;
+}
+
 } // namespace torchcraft

--- a/client/connection.cpp
+++ b/client/connection.cpp
@@ -109,7 +109,7 @@ bool Connection::receive(std::vector<uint8_t>& dest) {
   }
 } // receive
 
-bool Connection::poll(int timeout) {
+bool Connection::poll(long timeout) {
   short mask = ZMQ_POLLIN;
   zmq::pollitem_t items[] = {{sock_, 0, mask, 0}};
 

--- a/client/connection.h
+++ b/client/connection.h
@@ -60,7 +60,7 @@ class Connection {
   /// @return true if the receive operation succeeded
   bool receive(std::vector<uint8_t>& dest);
 
-  bool poll(int timeout);
+  bool poll(long timeout);
 
   int errnum() const {
     return errnum_;

--- a/include/client.h
+++ b/include/client.h
@@ -109,6 +109,10 @@ class Client {
   /// @return true if the receive operation succeeded, false otherwise
   bool receive(std::vector<std::string>& updates);
 
+  /// Blocks until a message is available for receive().
+  /// @return false on failure (timeout or lost connectivity), true otherwise
+  bool poll(long timeout = -1);
+
   std::string error() const {
     return error_;
   }


### PR DESCRIPTION
This is handy when locking access to torchcraft::State in client code, for
example, since Client::receive() will block until a reply from the server has
been received (or until a timeout occurs) before updating the game state.