### PR TITLE
Add basic text drawing commands

### DIFF
--- a/BWEnv/include/controller.h
+++ b/BWEnv/include/controller.h
@@ -41,7 +41,9 @@ enum Commands {
   DRAW_UNIT_LINE,     // uid1, uid2, color
   DRAW_UNIT_POS_LINE, // uid. x2, y2, color
   DRAW_CIRCLE,        // x, y, radius, color
-  DRAW_UNIT_CIRCLE,   // uid, radiu, color
+  DRAW_UNIT_CIRCLE,   // uid, radius, color
+  DRAW_TEXT,          // x, y + text
+  DRAW_TEXT_SCREEN,   // x, y + text
   // last command id
   COMMAND_END
 };
@@ -101,7 +103,7 @@ private:
   bool too_long_play_ = false;
   bool exit_process_ = false;
   bool with_image_ = false;
-  std::vector<std::vector<int>> draw_cmds_;
+  std::vector<std::pair<std::vector<int>, std::string>> draw_cmds_;
   torchcraft::fbs::FrameT tcframe_;
 };
 

--- a/BWEnv/src/controller.cc
+++ b/BWEnv/src/controller.cc
@@ -387,16 +387,19 @@ void Controller::handleCommand(int command, const std::vector<int>& args,
     case Commands::DRAW_UNIT_LINE:
     case Commands::DRAW_UNIT_POS_LINE:
     case Commands::DRAW_CIRCLE:
-    case Commands::DRAW_UNIT_CIRCLE: {
+    case Commands::DRAW_UNIT_CIRCLE:
+    case Commands::DRAW_TEXT:
+    case Commands::DRAW_TEXT_SCREEN: {
       static std::unordered_map<int, int> argcount = {
         {Commands::DRAW_LINE, 5}, {Commands::DRAW_UNIT_LINE, 3},
         {Commands::DRAW_UNIT_POS_LINE, 4}, {Commands::DRAW_CIRCLE, 4},
-        {Commands::DRAW_UNIT_CIRCLE, 3},
+        {Commands::DRAW_UNIT_CIRCLE, 3}, {Commands::DRAW_TEXT, 2},
+        {Commands::DRAW_TEXT_SCREEN, 2},
       };
       check_args(command, argcount[command]);
       std::vector<int> cmd({command});
       cmd.insert(cmd.end(), args.begin(), args.end());
-      draw_cmds_.push_back(cmd);
+      draw_cmds_.push_back({cmd, str});
       return;
     }
     case Commands::COMMAND_USER:
@@ -522,7 +525,9 @@ void Controller::clearLastFrame()
 
 void Controller::executeDrawCommands()
 {
-  for (const auto& cmd : draw_cmds_) {
+  for (const auto& cmdpair : draw_cmds_) {
+    auto cmd = cmdpair.first;
+    auto text = cmdpair.second;
     switch (cmd[0]) {
       case Commands::DRAW_LINE:
         BWAPI::Broodwar->drawLineMap(cmd.at(1), cmd.at(2), cmd.at(3),
@@ -558,6 +563,12 @@ void Controller::executeDrawCommands()
         }
         break;
       }
+      case Commands::DRAW_TEXT:
+        BWAPI::Broodwar->drawTextMap(cmd.at(1), cmd.at(2), text.c_str());
+        break;
+      case Commands::DRAW_TEXT_SCREEN:
+        BWAPI::Broodwar->drawTextScreen(cmd.at(1), cmd.at(2), text.c_str());
+        break;
     }
   }
 }

--- a/include/client.h
+++ b/include/client.h
@@ -44,17 +44,21 @@ class Client {
 
     Command() {}
     Command(int code) : code(code) {}
+    Command(int code, std::string str) : code(code), str(std::move(str)) {}
     Command(int code, std::initializer_list<int>&& args)
         : code(code), args(args) {}
-    template <typename... Ints>
-    Command(int code, Ints&&... args)
-        : Command(code, {std::forward<Ints>(args)...}) {}
-    Command(int code, std::string str) : code(code), str(std::move(str)) {}
+    Command(int code, std::string str, std::initializer_list<int>&& args)
+        : code(code), args(args), str(std::move(str)) {}
+    template <typename... Args>
+    Command(int code, int a, Args&&... args)
+        : Command(code, {a, std::forward<Args>(args)...}) {}
+    template <typename... Args>
+    Command(int code, std::string str, Args&&... args)
+        : Command(code, std::move(str), {std::forward<Args>(args)...}) {}
   };
 
  public:
   // LIFECYCLE
-
   Client();
   ~Client();
   Client(const Client&) = delete;

--- a/include/constants.h
+++ b/include/constants.h
@@ -63,8 +63,10 @@ BETTER_ENUM(
     DrawUnitPosLine = 19, // uid, x2, y2, color index
     DrawCircle = 20, //  x, y, radius, color index
     DrawUnitCircle = 21, // uid, radius, color index
+    DrawText = 22, // x, y plus text arg
+    DrawTextScreen = 23, // x, y plus text arg
 
-    MAX = 22)
+    MAX)
 
 BETTER_ENUM(
     UserCommandType,


### PR DESCRIPTION
This adds two new commands, DRAW_TEXT and DRAW_TEXT_SCREEN that make use of
BWAPI's text rendering functionality in pixel and screen coordinates,
respectively. This is useful for rendering debug information, for example.

The Client::Command constructors have been slightly refactored to enable
construction with a string argument alongside integer arguments.