### PR TITLE
Add status flags for units

### DIFF
--- a/include/frame.h
+++ b/include/frame.h
@@ -42,10 +42,51 @@ struct Order {
 };
 
 struct Unit {
+  enum Flags : int64_t {
+    BeingConstructed    = 1ll <<  4,
+    BeingGathered       = 1ll <<  5,
+    BeingHealed         = 1ll <<  6,
+    Blind               = 1ll <<  7,
+    Burrowed            = 1ll <<  9,
+    CarryingGas         = 1ll << 10,
+    CarryingMinerals    = 1ll << 11,
+    Constructing        = 1ll << 14,
+    DefenseMatrixed     = 1ll << 15,
+    Detected            = 1ll << 16,
+    Ensnared            = 1ll << 17,
+    GatheringGas        = 1ll << 20,
+    GatheringMinerals   = 1ll << 21,
+    Hallucination       = 1ll << 22,
+    Idle                = 1ll << 24,
+    Interruptible       = 1ll << 25,
+    Irradiated          = 1ll << 27,
+    Lifted              = 1ll << 28,
+    Loaded              = 1ll << 29,
+    LockedDown          = 1ll << 30,
+    Maelstrommed        = 1ll << 31,
+    Morphing            = 1ll << 32,
+    Parasited           = 1ll << 34,
+    Plagued             = 1ll << 36,
+    Powered             = 1ll << 37,
+    Repairing           = 1ll << 38,
+    Researching         = 1ll << 39,
+    Selected            = 1ll << 40,
+    Stasised            = 1ll << 43,
+    Stimmed             = 1ll << 44,
+    Stuck               = 1ll << 45,
+    Targetable          = 1ll << 46,
+    Training            = 1ll << 47,
+    UnderAttack         = 1ll << 48,
+    UnderDarkSwarm      = 1ll << 49,
+    UnderDisruptionWeb  = 1ll << 50,
+    UnderStorm          = 1ll << 51,
+    Upgrading           = 1ll << 52,
+  };
+
   int32_t id, x, y;
   int32_t health, max_health, shield, max_shield, energy;
   int32_t maxCD, groundCD, airCD;
-  bool idle, detected, lifted;
+  int64_t flags;
   int32_t visible;
   int32_t type, armor, shieldArmor, size;
 
@@ -216,6 +257,7 @@ class UnitDiff {
   std::vector<int32_t> order_diffs;
   int32_t order_size;
   double velocityX, velocityY;
+  int64_t flags;
 };
 
 Frame* add(Frame* frame, FrameDiff* diff);

--- a/lua/frame_lua.cpp
+++ b/lua/frame_lua.cpp
@@ -12,6 +12,50 @@
 using namespace std;
 using namespace torchcraft::replayer;
 
+namespace {
+
+std::unordered_map<int64_t, const char*> flagNames = {
+    {Unit::Flags::BeingConstructed, "being_constructed"},
+    {Unit::Flags::BeingGathered, "being_gathered"},
+    {Unit::Flags::BeingHealed, "being_healed"},
+    {Unit::Flags::Blind, "blind"},
+    {Unit::Flags::Burrowed, "burrowed"},
+    {Unit::Flags::CarryingGas, "carrying_gas"},
+    {Unit::Flags::CarryingMinerals, "carrying_minerals"},
+    {Unit::Flags::Constructing, "constructing"},
+    {Unit::Flags::DefenseMatrixed, "defense_matrixed"},
+    {Unit::Flags::Detected, "detected"},
+    {Unit::Flags::Ensnared, "ensnared"},
+    {Unit::Flags::GatheringGas, "gathering_gas"},
+    {Unit::Flags::GatheringMinerals, "gathering_minerals"},
+    {Unit::Flags::Hallucination, "hallucination"},
+    {Unit::Flags::Idle, "idle"},
+    {Unit::Flags::Interruptible, "interruptible"},
+    {Unit::Flags::Irradiated, "irradiated"},
+    {Unit::Flags::Lifted, "lifted"},
+    {Unit::Flags::Loaded, "loaded"},
+    {Unit::Flags::LockedDown, "locked_down"},
+    {Unit::Flags::Maelstrommed, "maelstrommed"},
+    {Unit::Flags::Morphing, "morphing"},
+    {Unit::Flags::Parasited, "parasited"},
+    {Unit::Flags::Plagued, "plagued"},
+    {Unit::Flags::Powered, "powered"},
+    {Unit::Flags::Repairing, "repairing"},
+    {Unit::Flags::Researching, "researching"},
+    {Unit::Flags::Selected, "selected"},
+    {Unit::Flags::Stasised, "stasised"},
+    {Unit::Flags::Stimmed, "stimmed"},
+    {Unit::Flags::Stuck, "stuck"},
+    {Unit::Flags::Targetable, "targetable"},
+    {Unit::Flags::Training, "training"},
+    {Unit::Flags::UnderAttack, "under_attack"},
+    {Unit::Flags::UnderDarkSwarm, "under_dark_swarm"},
+    {Unit::Flags::UnderDisruptionWeb, "under_disruption_web"},
+    {Unit::Flags::UnderStorm, "under_storm"},
+    {Unit::Flags::Upgrading, "upgrading"}};
+
+} // namespace
+
 // Utility
 
 Frame* checkFrame(lua_State* L, int id) {
@@ -86,6 +130,17 @@ void setBool(lua_State* L, const char* key, bool v) {
   lua_settable(L, -3);
 }
 
+void setFlags(lua_State* L, const char* key, int64_t flags) {
+  lua_pushstring(L, key);
+  lua_newtable(L);
+  for (auto& it : flagNames) {
+    lua_pushstring(L, it.second);
+    lua_pushboolean(L, flags & it.first);
+    lua_settable(L, -3);
+  }
+  lua_settable(L, -3);
+}
+
 // put's table[key] on top of the stack. don't forget to pop !
 bool getField(lua_State* L, const char* key) {
   lua_pushstring(L, key);
@@ -106,6 +161,16 @@ bool getBool(lua_State* L, const char* key) {
   lua_pop(L, 1);
   return res;
 };
+
+int64_t getFlags(lua_State* L, const char* key) {
+  getField(L, key);
+  int64_t flags = 0;
+  for (auto& it : flagNames) {
+    flags |= getBool(L, it.second) ? it.first : 0;
+  }
+  lua_pop(L, 1);
+  return flags;
+}
 
 void toFrame(lua_State* L, int id, Frame& res) {
   luaL_argcheck(L, lua_istable(L, id), 1, "'table' expected");
@@ -179,9 +244,19 @@ void toFrame(lua_State* L, int id, Frame& res) {
       unit.maxCD = getInt(L, "maxcd");
       unit.groundCD = getInt(L, "gwcd");
       unit.airCD = getInt(L, "awcd");
-      unit.idle = getBool(L, "idle");
-      unit.detected = getBool(L, "detected");
-      unit.lifted = getBool(L, "lifted");
+      unit.flags = getFlags(L, "flags");
+      if (getBool(L, "idle") != bool(unit.flags & Unit::Flags::Idle)) {
+        luaL_error(
+            L,
+            "inconsistent values for 'idle' in unit.flags for %d",
+            unit.id);
+      }
+      if (getBool(L, "detected") != bool(unit.flags & Unit::Flags::Idle)) {
+        luaL_error(
+            L,
+            "inconsistent values for 'detected' unit.flags for %d",
+            unit.id);
+      }
       unit.visible = getInt(L, "visible");
       unit.type = getInt(L, "type");
       unit.armor = getInt(L, "armor");
@@ -295,9 +370,10 @@ void pushUnit(lua_State* L, const Unit& unit) {
   setInt(L, "maxcd", unit.maxCD);
   setInt(L, "gwcd", unit.groundCD);
   setInt(L, "awcd", unit.airCD);
-  setBool(L, "idle", unit.idle);
-  setBool(L, "detected", unit.detected);
-  setBool(L, "lifted", unit.lifted);
+  setFlags(L, "flags", unit.flags);
+  // Backwards compatibility
+  setBool(L, "idle", unit.flags & Unit::Flags::Idle);
+  setBool(L, "detected", unit.flags & Unit::Flags::Detected);
   setInt(L, "visible", unit.visible);
   setInt(L, "armor", unit.armor);
   setInt(L, "shieldArmor", unit.shieldArmor);

--- a/replayer/frame.cpp
+++ b/replayer/frame.cpp
@@ -17,12 +17,11 @@ std::ostream& replayer::operator<<(std::ostream& out, const replayer::Unit& o) {
   out << o.id << " " << o.x << " " << o.y << " " << o.health << " "
       << o.max_health << " " << o.shield << " " << o.max_shield << " "
       << o.energy << " " << o.maxCD << " " << o.groundCD << " " << o.airCD
-      << " " << o.idle << " " << o.detected << " " << o.lifted << " "
-      << o.visible << " " << o.type << " " << o.armor << " " << o.shieldArmor
-      << " " << o.size << " " << o.pixel_x << " " << o.pixel_y << " "
-      << o.pixel_size_x << " " << o.pixel_size_y << " " << o.groundATK << " "
-      << o.airATK << " " << o.groundDmgType << " " << o.airDmgType << " "
-      << o.groundRange << " " << o.airRange << " ";
+      << " " << o.flags << " " << o.visible << " " << o.type << " " << o.armor
+      << " " << o.shieldArmor << " " << o.size << " " << o.pixel_x << " "
+      << o.pixel_y << " " << o.pixel_size_x << " " << o.pixel_size_y << " "
+      << o.groundATK << " " << o.airATK << " " << o.groundDmgType << " "
+      << o.airDmgType << " " << o.groundRange << " " << o.airRange << " ";
 
   out << o.orders.size() << " ";
   for (auto& c : o.orders) {
@@ -38,11 +37,11 @@ std::ostream& replayer::operator<<(std::ostream& out, const replayer::Unit& o) {
 
 std::istream& replayer::operator>>(std::istream& in, replayer::Unit& o) {
   in >> o.id >> o.x >> o.y >> o.health >> o.max_health >> o.shield >>
-      o.max_shield >> o.energy >> o.maxCD >> o.groundCD >> o.airCD >> o.idle >>
-      o.detected >> o.lifted >> o.visible >> o.type >> o.armor >>
-      o.shieldArmor >> o.size >> o.pixel_x >> o.pixel_y >> o.pixel_size_x >>
-      o.pixel_size_y >> o.groundATK >> o.airATK >> o.groundDmgType >>
-      o.airDmgType >> o.groundRange >> o.airRange;
+      o.max_shield >> o.energy >> o.maxCD >> o.groundCD >> o.airCD >> o.flags >>
+      o.visible >> o.type >> o.armor >> o.shieldArmor >> o.size >> o.pixel_x >>
+      o.pixel_y >> o.pixel_size_x >> o.pixel_size_y >> o.groundATK >>
+      o.airATK >> o.groundDmgType >> o.airDmgType >> o.groundRange >>
+      o.airRange;
 
   int n_orders;
   in >> n_orders;
@@ -225,7 +224,6 @@ namespace detail = replayer::detail;
   F(maxCD, 7)          \
   F(groundCD, 8)       \
   F(airCD, 9)          \
-  F(idle, 10)          \
   F(visible, 11)       \
   F(type, 12)          \
   F(armor, 13)         \
@@ -242,9 +240,7 @@ namespace detail = replayer::detail;
   F(groundRange, 24)   \
   F(airRange, 25)      \
   F(playerId, 26)      \
-  F(resources, 27)     \
-  F(detected, 28)      \
-  F(lifted, 29)
+  F(resources, 27)
 
 #define _DOALL_ON_ORDER(F) \
   F(first_frame, 0)        \
@@ -290,6 +286,7 @@ replayer::FrameDiff replayer::frame_diff(
       du.id = lit.id;
       du.velocityX = lit.velocityX;
       du.velocityY = lit.velocityY;
+      du.flags = lit.flags;
       du.order_size = lit.orders.size();
       if (rit != rhsu.end() &&
           lit.id == rit->id) { // Unit exists in both frames
@@ -370,6 +367,7 @@ replayer::Frame* detail::add(replayer::Frame* frame, replayer::FrameDiff* df) {
       u.id = du.id;
       u.velocityX = du.velocityX;
       u.velocityY = du.velocityY;
+      u.flags = du.flags;
 
       for (size_t k = 0; k < du.var_diffs.size(); k++) {
         switch (du.var_ids[k]) { // assumes int32_t are 0 initted
@@ -445,6 +443,7 @@ std::ostream& replayer::operator<<(
     std::ostream& out,
     const detail::UnitDiff& o) {
   out << o.id << " " << o.velocityX << " " << o.velocityY;
+  out << " " << o.flags;
   out << " " << o.var_ids.size();
   for (size_t i = 0; i < o.var_ids.size(); i++)
     out << " " << o.var_ids[i];
@@ -480,6 +479,7 @@ std::istream& replayer::operator>>(std::istream& in, detail::UnitDiff& o) {
   size_t nvars, norders;
 
   in >> o.id >> o.velocityX >> o.velocityY;
+  in >> o.flags;
   in >> nvars;
   o.var_ids.resize(nvars);
   o.var_diffs.resize(nvars);
@@ -550,6 +550,7 @@ bool detail::frameEq(replayer::Frame* f1, replayer::Frame* f2) {
 #undef _GEN_VAR
       _TEST(_EQV(units, [i].velocityX));
       _TEST(_EQV(units, [i].velocityY));
+      _TEST(_EQV(units, [i].flags));
       _TEST(_EQV(units, [i].orders.size()));
       for (size_t k = 0; k < f1units[i].orders.size(); k++)
         _TEST(_EQV(units, [i].orders[k]));


### PR DESCRIPTION
There's a lot of unit status information accessible via BWAPI as booleans, and
so far we restricted the information in TorchCraft to idle, detected and
visible. However, flags like constructing can also be helpful in certain
situations such as tracking a worker's progress.

Hence, this includes a single 64-bit integer that stores various status bits.
Furthermore, the conditions for including a unit in the frame sent to the client
have been relaxed -- it's now upon the client to ignore units that are not of
interest.