### PR TITLE
Clean up dependencies in rockspec

### DIFF
--- a/examples/progressbar.lua
+++ b/examples/progressbar.lua
@@ -9,11 +9,10 @@
 local tablex = require 'pl.tablex'
 local torch = require 'torch'
 local progress = torch.class('ProgressBar')
-local tds=require 'tds'
 local Threads = require 'threads'
 
 function progress:__init(id)
-    self.stringstore = tds.hash()
+    self.stringstore = {}
     self.mutex_id = id
 end
 

--- a/torchcraft-1.2-1.rockspec
+++ b/torchcraft-1.2-1.rockspec
@@ -15,8 +15,6 @@ description = {
 }
 dependencies = {
     "penlight",
-    "tds",
-    "lua-cjson",
     "torch >= 7.0",
 }
 build = {


### PR DESCRIPTION
cjson is not required any more, and we don't really need tds except for the
progress bar (where it just stores a single key).