### PR TITLE
Zstd compression support for replays

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,13 @@ IF(LUAROCKS_PREFIX)
     MESSAGE(STATUS "Prefix inferred from Luarocks: ${CMAKE_INSTALL_PREFIX}")
 ENDIF()
 FIND_PACKAGE(Torch REQUIRED)
-#SET(BUILD_STATIC yes)
+FIND_PACKAGE(PkgConfig REQUIRED)
+PKG_CHECK_MODULES(ZSTD libzstd)
 
 SET(CMAKE_CXX_FLAGS "-std=c++11 -Wall -fPIC -O2")
+IF(ZSTD_FOUND)
+    ADD_DEFINITIONS(-DWITH_ZSTD)
+ENDIF()
 
 INCLUDE_DIRECTORIES(
     ${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -28,6 +32,10 @@ SET_TARGET_PROPERTIES(torchcraft PROPERTIES
     VERSION   1.2.1
     SOVERSION 1.2.1)
 TARGET_LINK_LIBRARIES(torchcraft TH luaT zmq)
+IF(ZSTD_FOUND)
+    # Use the static library since we're using "advanced/experimental" features
+    TARGET_LINK_LIBRARIES(torchcraft ${ZSTD_LIBDIR}/libzstd.a)
+ENDIF()
 INSTALL(FILES ${headers}
         DESTINATION "${Torch_INSTALL_INCLUDE}/torchcraft"
 )

--- a/include/replayer.h
+++ b/include/replayer.h
@@ -121,6 +121,9 @@ class Replayer : public RefCounted {
 
   friend std::ostream& operator<<(std::ostream& out, const Replayer& o);
   friend std::istream& operator>>(std::istream& in, Replayer& o);
+
+  void load(const std::string& path);
+  void save(const std::string& path, bool compressed = false);
 };
 
 } // namespace replayer

--- a/lua/replayer_lua.cpp
+++ b/lua/replayer_lua.cpp
@@ -74,9 +74,14 @@ extern "C" int replayerSave(lua_State* L) {
   auto r = checkReplayer(L);
   auto path = luaL_checkstring(L, 2);
   bool compressed = false;
-#ifdef WITH_ZSTD
   if (lua_gettop(L) > 2) {
     compressed = lua_toboolean(L, 3);
+  }
+#ifndef WITH_ZSTD
+  if (compressed) {
+    std::cerr << "Warning: no Zstd support; disabling "
+              << "compression for saved replay" << std::endl;
+    compressed = false;
   }
 #endif
 

--- a/replayer/replayer.cpp
+++ b/replayer/replayer.cpp
@@ -10,6 +10,10 @@
 #include "replayer.h"
 #include <bitset>
 
+#ifdef WITH_ZSTD
+#include "zstdstream.h"
+#endif
+
 namespace torchcraft {
 namespace replayer {
 
@@ -182,6 +186,34 @@ void Replayer::getMap(
         start_loc_y.push_back(y);
       }
     }
+  }
+}
+
+void Replayer::load(const std::string& path) {
+#ifdef WITH_ZSTD
+  zstd::ifstream in(path);
+#else
+  std::ifstream in(path);
+#endif
+  in >> *this;
+  in.close();
+}
+
+void Replayer::save(const std::string& path, bool compressed) {
+#ifndef WITH_ZSTD
+  compressed = false;
+#endif
+
+  if (compressed) {
+#ifdef WITH_ZSTD
+    zstd::ofstream out(path);
+    out << *this;
+    out.close();
+#endif
+  } else {
+    std::ofstream out(path);
+    out << *this;
+    out.close();
   }
 }
 

--- a/replayer/replayer.cpp
+++ b/replayer/replayer.cpp
@@ -10,26 +10,28 @@
 #include "replayer.h"
 #include <bitset>
 
-namespace replayer = torchcraft::replayer;
+namespace torchcraft {
+namespace replayer {
 
 // Serialization
 
-std::ostream& replayer::operator<<(
-    std::ostream& out,
-    const replayer::Replayer& o) {
+std::ostream& operator<<(std::ostream& out, const Replayer& o) {
   auto height = THByteTensor_size(o.map.data, 0);
   auto width = THByteTensor_size(o.map.data, 1);
   auto data = THByteTensor_data(o.map.data);
 
-  if (o.keyframe != 0) out << 0 << " " << o.keyframe << " ";
+  if (o.keyframe != 0)
+    out << 0 << " " << o.keyframe << " ";
   out << height << " " << width << " ";
-  out.write((const char *)data, height * width); // Write map data as raw bytes
+  out.write((const char*)data, height * width); // Write map data as raw bytes
 
   auto kf = o.keyframe == 0 ? 1 : o.keyframe;
   out << o.frames.size() << " ";
   for (size_t i = 0; i < o.frames.size(); i++) {
-    if (i % kf == 0) out << *o.frames[i] << " ";
-    else out << replayer::frame_diff(o.frames[i], o.frames[i - 1]) << " ";
+    if (i % kf == 0)
+      out << *o.frames[i] << " ";
+    else
+      out << frame_diff(o.frames[i], o.frames[i - 1]) << " ";
   }
 
   out << o.numUnits.size() << " ";
@@ -40,7 +42,7 @@ std::ostream& replayer::operator<<(
   return out;
 }
 
-std::istream& replayer::operator>>(std::istream& in, replayer::Replayer& o) {
+std::istream& operator>>(std::istream& in, Replayer& o) {
   // WARNING: cases were observed where this operator left a Replayer
   // that was in a corrupted state, and would produce a segfault
   // if we tried to delete it.
@@ -50,7 +52,8 @@ std::istream& replayer::operator>>(std::istream& in, replayer::Replayer& o) {
   int32_t height, width;
   in >> diffed;
 
-  if (diffed == 0) in >> o.keyframe >> height >> width;
+  if (diffed == 0)
+    in >> o.keyframe >> height >> width;
   else {
     height = diffed;
     in >> width;
@@ -70,16 +73,14 @@ std::istream& replayer::operator>>(std::istream& in, replayer::Replayer& o) {
     if (o.keyframe == 0) {
       o.frames[i] = new Frame();
       in >> *o.frames[i];
-    }
-    else {
+    } else {
       if (i % o.keyframe == 0) {
         o.frames[i] = new Frame();
         in >> *o.frames[i];
-      }
-      else {
-        replayer::FrameDiff du;
+      } else {
+        FrameDiff du;
         in >> du;
-        o.frames[i] = replayer::frame_undiff(&du, o.frames[i-1]);
+        o.frames[i] = frame_undiff(&du, o.frames[i - 1]);
       }
     }
   }
@@ -97,18 +98,23 @@ std::istream& replayer::operator>>(std::istream& in, replayer::Replayer& o) {
   return in;
 }
 
-void replayer::Replayer::setMap(THByteTensor* walkability,
-    THByteTensor* ground_height, THByteTensor* buildability,
-    std::vector<int>& start_loc_x, std::vector<int>& start_loc_y) {
+void Replayer::setMap(
+    THByteTensor* walkability,
+    THByteTensor* ground_height,
+    THByteTensor* buildability,
+    std::vector<int>& start_loc_x,
+    std::vector<int>& start_loc_y) {
   walkability = THByteTensor_newContiguous(walkability);
   ground_height = THByteTensor_newContiguous(ground_height);
   buildability = THByteTensor_newContiguous(buildability);
-  replayer::Replayer::setMap(
-      THByteTensor_size(walkability, 0), THByteTensor_size(walkability, 1),
+  Replayer::setMap(
+      THByteTensor_size(walkability, 0),
+      THByteTensor_size(walkability, 1),
       THByteTensor_data(walkability),
       THByteTensor_data(ground_height),
       THByteTensor_data(buildability),
-      start_loc_x, start_loc_y);
+      start_loc_x,
+      start_loc_y);
   THByteTensor_free(walkability);
   THByteTensor_free(ground_height);
   THByteTensor_free(buildability);
@@ -120,10 +126,14 @@ void replayer::Replayer::setMap(THByteTensor* walkability,
 // height is 0-5, hence 3 bits
 #define START_LOC_SHIFT 5
 
-
-void replayer::Replayer::setMap(int32_t h, int32_t w,
-    uint8_t* walkability, uint8_t* ground_height, uint8_t* buildability,
-    std::vector<int>& start_loc_x, std::vector<int>& start_loc_y) {
+void Replayer::setMap(
+    int32_t h,
+    int32_t w,
+    uint8_t* walkability,
+    uint8_t* ground_height,
+    uint8_t* buildability,
+    std::vector<int>& start_loc_x,
+    std::vector<int>& start_loc_y) {
   if (map.data != nullptr) {
     THByteTensor_free(map.data);
   }
@@ -135,12 +145,11 @@ void replayer::Replayer::setMap(int32_t h, int32_t w,
       // Ground height only goes up to 5
       uint8_t v_g = ground_height[y * w + x] & 0b111;
       uint8_t packed = (v_w << WALKABILITY_SHIFT) |
-        (v_b << BUILDABILITY_SHIFT) |
-        (v_g << HEIGHT_SHIFT);
+          (v_b << BUILDABILITY_SHIFT) | (v_g << HEIGHT_SHIFT);
       THTensor_fastSet2d(map.data, y, x, packed);
     }
   }
-  for (int i=0; i<start_loc_x.size(); i++) {
+  for (int i = 0; i < start_loc_x.size(); i++) {
     auto x = start_loc_x[i];
     auto y = start_loc_y[i];
     auto v = THTensor_fastGet2d(map.data, y, x) | (1 << START_LOC_SHIFT);
@@ -148,9 +157,12 @@ void replayer::Replayer::setMap(int32_t h, int32_t w,
   }
 }
 
-void replayer::Replayer::getMap(THByteTensor* walkability,
-    THByteTensor* ground_height, THByteTensor* buildability,
-    std::vector<int>& start_loc_x, std::vector<int>& start_loc_y) {
+void Replayer::getMap(
+    THByteTensor* walkability,
+    THByteTensor* ground_height,
+    THByteTensor* buildability,
+    std::vector<int>& start_loc_x,
+    std::vector<int>& start_loc_y) {
   auto h = THByteTensor_size(map.data, 0);
   auto w = THByteTensor_size(map.data, 1);
   THByteTensor_resizeAs(walkability, map.data);
@@ -172,3 +184,6 @@ void replayer::Replayer::getMap(THByteTensor* walkability,
     }
   }
 }
+
+} // namespace replayer
+} // namespace torchcraft

--- a/replayer/replayer.cpp
+++ b/replayer/replayer.cpp
@@ -201,7 +201,11 @@ void Replayer::load(const std::string& path) {
 
 void Replayer::save(const std::string& path, bool compressed) {
 #ifndef WITH_ZSTD
-  compressed = false;
+  if (compressed) {
+    std::cerr << "Warning: no Zstd support; disabling "
+              << "compression for saved replay" << std::endl;
+    compressed = false;
+  }
 #endif
 
   if (compressed) {

--- a/replayer/zstdstream.h
+++ b/replayer/zstdstream.h
@@ -1,0 +1,309 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * STL stream classes for Zstd compression and decompression.
+ * Partially inspired by https://github.com/mateidavid/zstr.
+ */
+
+#pragma once
+
+#include <cassert>
+#include <fstream>
+#include <vector>
+
+// Required to access ZSTD_isFrame()
+#define ZSTD_STATIC_LINKING_ONLY
+#include <zstd.h>
+
+namespace zstd {
+
+// Custom exception for zstd error codes
+class exception : public std::exception {
+ public:
+  exception(int code) : msg_("zstd: ") {
+    msg_ += ZSTD_getErrorName(code);
+  }
+
+  const char* what() const throw() {
+    return msg_.c_str();
+  };
+
+ private:
+  std::string msg_;
+};
+
+inline size_t check(size_t code) {
+  if (ZSTD_isError(code)) {
+    throw exception(code);
+  }
+  return code;
+}
+
+// Provides stream compression functionality
+class cstream {
+ public:
+  static const int defaultLevel = 5;
+
+  cstream(int level = defaultLevel) : ended_(false) {
+    cstr_ = ZSTD_createCStream();
+    if (cstr_ == nullptr) {
+    }
+    check(ZSTD_initCStream(cstr_, level));
+  }
+
+  ~cstream() {
+    check(ZSTD_freeCStream(cstr_));
+  }
+
+  size_t compress(ZSTD_outBuffer* output, ZSTD_inBuffer* input) {
+    return check(ZSTD_compressStream(cstr_, output, input));
+  }
+
+  size_t end(ZSTD_outBuffer* output) {
+    auto ret = check(ZSTD_endStream(cstr_, output));
+    ended_ = true;
+    return ret;
+  }
+
+  bool ended() const {
+    return ended_;
+  }
+
+ private:
+  ZSTD_CStream* cstr_;
+  bool ended_;
+};
+
+// Provides stream decompression functionality
+class dstream {
+ public:
+  static const int defaultLevel = 3;
+
+  dstream() {
+    dstr_ = ZSTD_createDStream();
+    if (dstr_ == nullptr) {
+    }
+    check(ZSTD_initDStream(dstr_));
+  }
+
+  ~dstream() {
+    check(ZSTD_freeDStream(dstr_));
+  }
+
+  size_t decompress(ZSTD_outBuffer* output, ZSTD_inBuffer* input) {
+    return check(ZSTD_decompressStream(dstr_, output, input));
+  }
+
+ private:
+  ZSTD_DStream* dstr_;
+};
+
+// Zstd stream for compression. Data is written in a single big frame.
+class ostreambuf : public std::streambuf {
+ public:
+  ostreambuf(std::streambuf* sbuf, int level = cstream::defaultLevel)
+      : sbuf_(sbuf), str_(level) {
+    inbuf_.resize(ZSTD_CStreamInSize());
+    outbuf_.resize(ZSTD_CStreamOutSize());
+    inhint_ = inbuf_.size();
+    setp(inbuf_.data(), inbuf_.data() + inhint_);
+  }
+
+  virtual ~ostreambuf() {
+    sync();
+  }
+
+  virtual int_type overflow(int_type ch = traits_type::eof()) {
+    auto pos = compress(pptr() - pbase());
+    if (pos < 0) {
+      setp(nullptr, nullptr);
+      return traits_type::eof();
+    }
+    setp(inbuf_.data() + pos, inbuf_.data() + inhint_);
+    return ch == traits_type::eof() ? traits_type::eof() : sputc(ch);
+  }
+
+  virtual int sync() {
+    overflow();
+    if (!pptr() || str_.ended()) {
+      return -1;
+    }
+
+    // Flush and finish the Zstd frame
+    ZSTD_outBuffer output = {outbuf_.data(), outbuf_.size(), 0};
+    auto ret = str_.end(&output);
+    check(ret);
+    if (ret) {
+      throw std::runtime_error(std::string("zstd: ") + "not fully flushed");
+    }
+    if (sbuf_->sputn(reinterpret_cast<char*>(output.dst), output.pos) !=
+        output.pos) {
+      return -1;
+    }
+    return 0;
+  }
+
+ private:
+  ssize_t compress(size_t pos) {
+    ZSTD_inBuffer input = {inbuf_.data(), pos, 0};
+    while (input.pos != input.size) {
+      ZSTD_outBuffer output = {outbuf_.data(), outbuf_.size(), 0};
+      auto ret = str_.compress(&output, &input);
+      check(ret);
+      inhint_ = std::min(ret, inbuf_.size());
+
+      if (output.pos > 0 &&
+          sbuf_->sputn(reinterpret_cast<char*>(output.dst), output.pos) !=
+              output.pos) {
+        return -1;
+      }
+    }
+
+    return 0;
+  }
+
+  std::streambuf* sbuf_;
+  cstream str_;
+  std::vector<char> inbuf_;
+  std::vector<char> outbuf_;
+  size_t inhint_;
+};
+
+// Zstd stream for decompression. If input data is not compressed, this stream
+// will simply copy it.
+class istreambuf : public std::streambuf {
+ public:
+  istreambuf(std::streambuf* sbuf, int level = cstream::defaultLevel)
+      : sbuf_(sbuf) {
+    inbuf_.resize(ZSTD_DStreamInSize());
+    inhint_ = inbuf_.size();
+    setg(inbuf_.data(), inbuf_.data(), inbuf_.data());
+  }
+
+  virtual std::streambuf::int_type underflow() {
+    if (gptr() != egptr()) {
+      return traits_type::eof();
+    }
+
+    if (inpos_ >= inavail_) {
+      inavail_ = sbuf_->sgetn(inbuf_.data(), inhint_);
+      if (inavail_ == 0) {
+        return traits_type::eof();
+      }
+      inpos_ = 0;
+    }
+
+    // Check whether data is actually compressed
+    if (!detected_) {
+      compressed_ = ZSTD_isFrame(inbuf_.data(), inavail_);
+      detected_ = true;
+      if (compressed_) {
+        outbuf_.resize(ZSTD_DStreamOutSize());
+      }
+    }
+
+    if (compressed_) {
+      // Consume input
+      ZSTD_inBuffer input = {inbuf_.data(), inavail_, inpos_};
+      ZSTD_outBuffer output = {outbuf_.data(), outbuf_.size(), 0};
+      auto ret = str_.decompress(&output, &input);
+      check(ret);
+      inhint_ = std::min(ret, inbuf_.size());
+      inpos_ = input.pos;
+      setg(outbuf_.data(), outbuf_.data(), outbuf_.data() + output.pos);
+    } else {
+      // Re-use inbuf_ to avoid extra copy
+      inpos_ = inavail_;
+      setg(inbuf_.data(), inbuf_.data(), inbuf_.data() + inavail_);
+    }
+
+    return gptr() == egptr() ? traits_type::eof()
+                             : traits_type::to_int_type(*gptr());
+  }
+
+ private:
+  std::streambuf* sbuf_;
+  dstream str_;
+  std::vector<char> inbuf_;
+  std::vector<char> outbuf_; // only needed if actually compressed
+  size_t inhint_;
+  size_t inpos_ = 0;
+  size_t inavail_ = 0;
+  bool detected_ = false;
+  bool compressed_ = false;
+};
+
+// This class enables [io]fstream below to inherit from [io]stream (required for
+// setting a custom streambuf) while still constructing a corresponding
+// [io]fstream first (required for initializing the Zstd streambufs).
+template <typename T>
+class fsholder {
+ public:
+  fsholder(
+      const std::string& path,
+      std::ios_base::openmode mode = std::ios_base::out)
+      : fs_(path, mode) {}
+
+ protected:
+  T fs_;
+};
+
+// Output file stream that writes Zstd-compressed data
+class ofstream : private fsholder<std::ofstream>, public std::ostream {
+ public:
+  ofstream(
+      const std::string& path,
+      std::ios_base::openmode mode = std::ios_base::out)
+      : fsholder<std::ofstream>(path, mode | std::ios_base::binary),
+        std::ostream(new ostreambuf(fs_.rdbuf())) {
+    exceptions(std::ios_base::badbit);
+  }
+
+  virtual ~ofstream() {
+    if (rdbuf()) {
+      delete rdbuf();
+    }
+  }
+
+  virtual operator bool() const {
+    return bool(fs_);
+  }
+
+  void close() {
+    flush();
+    fs_.close();
+  }
+};
+
+// Input file stream for Zstd-compressed data
+class ifstream : private fsholder<std::ifstream>, public std::istream {
+ public:
+  ifstream(
+      const std::string& path,
+      std::ios_base::openmode mode = std::ios_base::in)
+      : fsholder<std::ifstream>(path, mode | std::ios_base::binary),
+        std::istream(new istreambuf(fs_.rdbuf())) {
+    exceptions(std::ios_base::badbit);
+  }
+
+  virtual ~ifstream() {
+    if (rdbuf()) {
+      delete rdbuf();
+    }
+  }
+
+  operator bool() const {
+    return bool(fs_);
+  }
+
+  void close() {
+    fs_.close();
+  }
+};
+
+} // namespace zstd


### PR DESCRIPTION
This adds detection of zstd to the build system (reflected via the `WITH_ZSTD`
pre-processor symbol) and drop-in replacements for std::ifstream and
std::ofstream that read and write data using Zstd. zstd::ifstream will
automatically detected whether it is reading uncompressed data and will resort
to copy-through in this case.

Replayer is aware of Zstd support, which still has to be enabled explicitly by
the user at this point. In preliminary experiments, replay data could be
compressed by a huge factor, even when containing frame diffs. Please let
me know if you think it'll be a good idea to enable compression by default.

For testing, I used [this little script](https://gist.github.com/jgehring/b8625170bc00ed9bdc7813f3ccee3f9f) on a dump of the replay included in maps/
(bwrep_axkn5.rep). Note that this test includes #100. When loading an
uncompressed replay:
> Loading... 5.23s, 48390kiB
> Saving w/ compression... 5.23s, 22kiB
> Saving w/o compression... 5.86s, 48390kiB

Loading a compressed replay:
> Loading... 5.04s, 22kiB
> Saving w/ compression... 5.24s, 21kiB
> Saving w/o compression... 5.91s, 48390kiB

I used the zstd command-line tool to verify that I'm actually writing valid data.
Also, the different file sizes for the compressed data are very likely due to
unordered_maps (e.g. player to unit mapping) being saved in a different order.
When reading both files back in, the resulting data and frames are exactly the
same (according to deepEq).