### PR TITLE
Add command status codes to server messages

### DIFF
--- a/BWEnv/fbs/messages.fbs
+++ b/BWEnv/fbs/messages.fbs
@@ -47,10 +47,11 @@ table Commands {
 }
 
 table Frame {
-  data:[ubyte]; // serialized frame data
+  data:[ubyte];                 // serialized frame data
   deaths:[int];
   frame_from_bwapi:int;
   battle_frame_count:int;
+  commands_status:[byte];       // Status for previous commands (zero == success)
   
   // if with_image
   img_mode:string;

--- a/BWEnv/fbs/messages_generated.h
+++ b/BWEnv/fbs/messages_generated.h
@@ -500,6 +500,7 @@ struct FrameT : public flatbuffers::NativeTable {
   std::vector<int32_t> deaths;
   int32_t frame_from_bwapi;
   int32_t battle_frame_count;
+  std::vector<int8_t> commands_status;
   std::string img_mode;
   std::unique_ptr<Vec2> screen_position;
   std::vector<uint8_t> visibility;
@@ -518,12 +519,13 @@ struct Frame FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_DEATHS = 6,
     VT_FRAME_FROM_BWAPI = 8,
     VT_BATTLE_FRAME_COUNT = 10,
-    VT_IMG_MODE = 12,
-    VT_SCREEN_POSITION = 14,
-    VT_VISIBILITY = 16,
-    VT_VISIBILITY_SIZE = 18,
-    VT_IMG_DATA = 20,
-    VT_IMG_SIZE = 22
+    VT_COMMANDS_STATUS = 12,
+    VT_IMG_MODE = 14,
+    VT_SCREEN_POSITION = 16,
+    VT_VISIBILITY = 18,
+    VT_VISIBILITY_SIZE = 20,
+    VT_IMG_DATA = 22,
+    VT_IMG_SIZE = 24
   };
   const flatbuffers::Vector<uint8_t> *data() const { return GetPointer<const flatbuffers::Vector<uint8_t> *>(VT_DATA); }
   flatbuffers::Vector<uint8_t> *mutable_data() { return GetPointer<flatbuffers::Vector<uint8_t> *>(VT_DATA); }
@@ -533,6 +535,8 @@ struct Frame FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   bool mutate_frame_from_bwapi(int32_t _frame_from_bwapi) { return SetField(VT_FRAME_FROM_BWAPI, _frame_from_bwapi); }
   int32_t battle_frame_count() const { return GetField<int32_t>(VT_BATTLE_FRAME_COUNT, 0); }
   bool mutate_battle_frame_count(int32_t _battle_frame_count) { return SetField(VT_BATTLE_FRAME_COUNT, _battle_frame_count); }
+  const flatbuffers::Vector<int8_t> *commands_status() const { return GetPointer<const flatbuffers::Vector<int8_t> *>(VT_COMMANDS_STATUS); }
+  flatbuffers::Vector<int8_t> *mutable_commands_status() { return GetPointer<flatbuffers::Vector<int8_t> *>(VT_COMMANDS_STATUS); }
   const flatbuffers::String *img_mode() const { return GetPointer<const flatbuffers::String *>(VT_IMG_MODE); }
   flatbuffers::String *mutable_img_mode() { return GetPointer<flatbuffers::String *>(VT_IMG_MODE); }
   const Vec2 *screen_position() const { return GetStruct<const Vec2 *>(VT_SCREEN_POSITION); }
@@ -553,6 +557,8 @@ struct Frame FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            verifier.Verify(deaths()) &&
            VerifyField<int32_t>(verifier, VT_FRAME_FROM_BWAPI) &&
            VerifyField<int32_t>(verifier, VT_BATTLE_FRAME_COUNT) &&
+           VerifyField<flatbuffers::uoffset_t>(verifier, VT_COMMANDS_STATUS) &&
+           verifier.Verify(commands_status()) &&
            VerifyField<flatbuffers::uoffset_t>(verifier, VT_IMG_MODE) &&
            verifier.Verify(img_mode()) &&
            VerifyField<Vec2>(verifier, VT_SCREEN_POSITION) &&
@@ -575,6 +581,7 @@ struct FrameBuilder {
   void add_deaths(flatbuffers::Offset<flatbuffers::Vector<int32_t>> deaths) { fbb_.AddOffset(Frame::VT_DEATHS, deaths); }
   void add_frame_from_bwapi(int32_t frame_from_bwapi) { fbb_.AddElement<int32_t>(Frame::VT_FRAME_FROM_BWAPI, frame_from_bwapi, 0); }
   void add_battle_frame_count(int32_t battle_frame_count) { fbb_.AddElement<int32_t>(Frame::VT_BATTLE_FRAME_COUNT, battle_frame_count, 0); }
+  void add_commands_status(flatbuffers::Offset<flatbuffers::Vector<int8_t>> commands_status) { fbb_.AddOffset(Frame::VT_COMMANDS_STATUS, commands_status); }
   void add_img_mode(flatbuffers::Offset<flatbuffers::String> img_mode) { fbb_.AddOffset(Frame::VT_IMG_MODE, img_mode); }
   void add_screen_position(const Vec2 *screen_position) { fbb_.AddStruct(Frame::VT_SCREEN_POSITION, screen_position); }
   void add_visibility(flatbuffers::Offset<flatbuffers::Vector<uint8_t>> visibility) { fbb_.AddOffset(Frame::VT_VISIBILITY, visibility); }
@@ -584,7 +591,7 @@ struct FrameBuilder {
   FrameBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb) { start_ = fbb_.StartTable(); }
   FrameBuilder &operator=(const FrameBuilder &);
   flatbuffers::Offset<Frame> Finish() {
-    auto o = flatbuffers::Offset<Frame>(fbb_.EndTable(start_, 10));
+    auto o = flatbuffers::Offset<Frame>(fbb_.EndTable(start_, 11));
     return o;
   }
 };
@@ -594,6 +601,7 @@ inline flatbuffers::Offset<Frame> CreateFrame(flatbuffers::FlatBufferBuilder &_f
     flatbuffers::Offset<flatbuffers::Vector<int32_t>> deaths = 0,
     int32_t frame_from_bwapi = 0,
     int32_t battle_frame_count = 0,
+    flatbuffers::Offset<flatbuffers::Vector<int8_t>> commands_status = 0,
     flatbuffers::Offset<flatbuffers::String> img_mode = 0,
     const Vec2 *screen_position = 0,
     flatbuffers::Offset<flatbuffers::Vector<uint8_t>> visibility = 0,
@@ -607,6 +615,7 @@ inline flatbuffers::Offset<Frame> CreateFrame(flatbuffers::FlatBufferBuilder &_f
   builder_.add_visibility(visibility);
   builder_.add_screen_position(screen_position);
   builder_.add_img_mode(img_mode);
+  builder_.add_commands_status(commands_status);
   builder_.add_battle_frame_count(battle_frame_count);
   builder_.add_frame_from_bwapi(frame_from_bwapi);
   builder_.add_deaths(deaths);
@@ -619,13 +628,14 @@ inline flatbuffers::Offset<Frame> CreateFrameDirect(flatbuffers::FlatBufferBuild
     const std::vector<int32_t> *deaths = nullptr,
     int32_t frame_from_bwapi = 0,
     int32_t battle_frame_count = 0,
+    const std::vector<int8_t> *commands_status = nullptr,
     const char *img_mode = nullptr,
     const Vec2 *screen_position = 0,
     const std::vector<uint8_t> *visibility = nullptr,
     const Vec2 *visibility_size = 0,
     const std::vector<uint8_t> *img_data = nullptr,
     const Vec2 *img_size = 0) {
-  return CreateFrame(_fbb, data ? _fbb.CreateVector<uint8_t>(*data) : 0, deaths ? _fbb.CreateVector<int32_t>(*deaths) : 0, frame_from_bwapi, battle_frame_count, img_mode ? _fbb.CreateString(img_mode) : 0, screen_position, visibility ? _fbb.CreateVector<uint8_t>(*visibility) : 0, visibility_size, img_data ? _fbb.CreateVector<uint8_t>(*img_data) : 0, img_size);
+  return CreateFrame(_fbb, data ? _fbb.CreateVector<uint8_t>(*data) : 0, deaths ? _fbb.CreateVector<int32_t>(*deaths) : 0, frame_from_bwapi, battle_frame_count, commands_status ? _fbb.CreateVector<int8_t>(*commands_status) : 0, img_mode ? _fbb.CreateString(img_mode) : 0, screen_position, visibility ? _fbb.CreateVector<uint8_t>(*visibility) : 0, visibility_size, img_data ? _fbb.CreateVector<uint8_t>(*img_data) : 0, img_size);
 }
 
 inline flatbuffers::Offset<Frame> CreateFrame(flatbuffers::FlatBufferBuilder &_fbb, const FrameT *_o, const flatbuffers::rehasher_function_t *rehasher = nullptr);
@@ -961,6 +971,7 @@ inline FrameT *Frame::UnPack(const flatbuffers::resolver_function_t *resolver) c
   { auto _e = deaths(); if (_e) { for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->deaths.push_back(_e->Get(_i)); } } };
   { auto _e = frame_from_bwapi(); _o->frame_from_bwapi = _e; };
   { auto _e = battle_frame_count(); _o->battle_frame_count = _e; };
+  { auto _e = commands_status(); if (_e) { for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->commands_status.push_back(_e->Get(_i)); } } };
   { auto _e = img_mode(); if (_e) _o->img_mode = _e->str(); };
   { auto _e = screen_position(); if (_e) _o->screen_position = std::unique_ptr<Vec2>(new Vec2(*_e)); };
   { auto _e = visibility(); if (_e) { for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->visibility.push_back(_e->Get(_i)); } } };
@@ -981,6 +992,7 @@ inline flatbuffers::Offset<Frame> CreateFrame(flatbuffers::FlatBufferBuilder &_f
     _o->deaths.size() ? _fbb.CreateVector(_o->deaths) : 0,
     _o->frame_from_bwapi,
     _o->battle_frame_count,
+    _o->commands_status.size() ? _fbb.CreateVector(_o->commands_status) : 0,
     _o->img_mode.size() ? _fbb.CreateString(_o->img_mode) : 0,
     _o->screen_position ? _o->screen_position.get() : 0,
     _o->visibility.size() ? _fbb.CreateVector(_o->visibility) : 0,

--- a/BWEnv/include/ZMQ_server.h
+++ b/BWEnv/include/ZMQ_server.h
@@ -41,7 +41,7 @@ public:
   void sendError(const torchcraft::fbs::ErrorT *error);
   void receiveMessage();
   void handleReconnect(const torchcraft::fbs::HandshakeClient* handshake);
-  void handleCommands(const torchcraft::fbs::Commands* commands);
+  std::vector<int8_t> handleCommands(const torchcraft::fbs::Commands* commands);
   int getPort();
 };
 

--- a/BWEnv/include/controller.h
+++ b/BWEnv/include/controller.h
@@ -48,15 +48,18 @@ enum Commands {
   COMMAND_END
 };
 
-enum CommandStatus {
-  UNKNOWN_ERROR = -1,
+enum CommandStatus : int8_t {
   SUCCESS = 0,
-  BWAPI_ERROR = 1,
-  UNKNOWN_COMMAND = 2,
-  MISSING_ARGUMENTS = 3,
-  TOO_MANY_COMMANDS = 4,
-  INVALID_UNIT = 5,
-  PROTECTED = 6,
+  // Positive numbers correspond to
+  // BWAPI error codes from BWAPI::Errors::Enum | BWAPI_ERROR
+  // (since an error code of 0 also signals an error in BWAPI)
+  BWAPI_ERROR_MASK = 0x40,
+  UNKNOWN_ERROR = -1,
+  UNKNOWN_COMMAND = -2,
+  MISSING_ARGUMENTS = -3,
+  TOO_MANY_COMMANDS = -4,
+  INVALID_UNIT = -5,
+  PROTECTED = -6,
 };
 
 class Controller

--- a/BWEnv/include/controller.h
+++ b/BWEnv/include/controller.h
@@ -48,6 +48,17 @@ enum Commands {
   COMMAND_END
 };
 
+enum CommandStatus {
+  UNKNOWN_ERROR = -1,
+  SUCCESS = 0,
+  BWAPI_ERROR = 1,
+  UNKNOWN_COMMAND = 2,
+  MISSING_ARGUMENTS = 3,
+  TOO_MANY_COMMANDS = 4,
+  INVALID_UNIT = 5,
+  PROTECTED = 6,
+};
+
 class Controller
 {
 public:
@@ -58,9 +69,10 @@ public:
   void loop();
   void initGame();
   void setupHandshake();
-  void handleCommand(int command, const std::vector<int>& args,
+  int8_t handleCommand(int command, const std::vector<int>& args,
     const std::string& str);
-  void handleUserCommand(int command, const std::vector<int>& args);
+  int8_t handleUserCommand(int command, const std::vector<int>& args);
+  void setCommandsStatus(std::vector<int8_t> status);
   BWAPI::Position getPositionFromWalkTiles(int x, int y);
   BWAPI::TilePosition getTilePositionFromWalkTiles(int x, int y);
   int getAttackFrames(int unitID);

--- a/BWEnv/src/controller.cc
+++ b/BWEnv/src/controller.cc
@@ -360,7 +360,7 @@ int8_t Controller::handleCommand(int command, const std::vector<int>& args,
         x, y, extra))) {
         Utils::bwlog(output_log, "Commanding unit failed! Error: %s",
           BWAPI::Broodwar->getLastError().c_str());
-        return CommandStatus::BWAPI_ERROR;
+        return CommandStatus::BWAPI_ERROR_MASK | BWAPI::Broodwar->getLastError().getID();
       }
       return CommandStatus::SUCCESS;
     case Commands::COMMAND_UNIT_PROTECTED:
@@ -386,7 +386,7 @@ int8_t Controller::handleCommand(int command, const std::vector<int>& args,
           target, x, y, extra))) {
           Utils::bwlog(output_log, "Commanding unit failed! Error: %s",
             BWAPI::Broodwar->getLastError().c_str());
-          status = CommandStatus::BWAPI_ERROR;
+          status = CommandStatus::BWAPI_ERROR_MASK | BWAPI::Broodwar->getLastError().getID();
         } else {
           status = CommandStatus::SUCCESS;
         }

--- a/include/client.h
+++ b/include/client.h
@@ -121,6 +121,13 @@ class Client {
     return error_;
   }
 
+  std::vector<Command> lastCommands() const {
+    return lastCommands_;
+  }
+  std::vector<int8_t> lastCommandsStatus() const {
+    return lastCommandsStatus_;
+  }
+
   State* state() const {
     return state_;
   }
@@ -136,6 +143,8 @@ class Client {
   bool sent_;
   std::string error_;
   std::string uid_;
+  std::vector<Command> lastCommands_;
+  std::vector<int8_t> lastCommandsStatus_;
 };
 
 } // namespace torchcraft


### PR DESCRIPTION
This adds a `commands_status` field to the server's Frame message. It contains a
return code for each command that the client issued in its previous message, in
the same order as the original commands. A return code of zero indicates
success, and any other value signals an error. This should be mainly useful for
debugging as it is tedious to constantly check the server's error log for failed
commands. Note that for every command issued via BWAPI, there is still a small
chance that it will fail even if its return code is zero.

The exact error codes are currently internal to the server code since I assumed
it would not be that useful to expose them on the client side. This can be
changed later, of course.
