### PR TITLE
Fixing #122

### DIFF
--- a/py/pyreplayer.cpp
+++ b/py/pyreplayer.cpp
@@ -173,7 +173,10 @@ void init_replayer(py::module& m) {
   py::class_<Replayer>(m_sub, "Replayer")
       .def(py::init<>())
       .def("__len__", &Replayer::size)
-      .def("getFrame", &Replayer::getFrame)
+      .def(
+          "getFrame",
+          &Replayer::getFrame,
+          py::return_value_policy::reference_internal)
       .def("push", &Replayer::push)
       .def("setKeyFrame", &Replayer::setKeyFrame)
       .def("getKeyFrame", &Replayer::getKeyFrame)


### PR DESCRIPTION
Pybind will take ownership of the returned Frame pointer, and tries to free it when it goes out of scope. Instead, Replayer should take onwership of this pointer and python should simply reference it. reference_internal keeps the parent Replayer alive as long as the Frame* is alive.