### PR TITLE
Update State uservalue on request

### DIFF
--- a/client/state.cpp
+++ b/client/state.cpp
@@ -55,6 +55,8 @@ void State::reset() {
   aliveUnits.clear();
   aliveUnitsConsidered.clear();
   units.clear();
+
+  numUpdates++;
 }
 
 std::vector<std::string> State::update(
@@ -227,6 +229,8 @@ bool State::setRawImage(const torchcraft::fbs::Frame* frame) {
 }
 
 void State::postUpdate(std::vector<std::string>& upd) {
+  numUpdates++;
+
   if (microBattles_) {
     if (battle_just_ended) {
       upd.emplace_back("battle_just_ended");

--- a/include/state.h
+++ b/include/state.h
@@ -101,6 +101,10 @@ class State : public RefCounted {
   //   battle is considered finished, i.e. it corresponds to aliveUnits.
   std::unordered_map<int32_t, std::vector<Unit>> units;
 
+  // Total number of updates received since creation (resets are counted as
+  // well).
+  uint64_t numUpdates = 0;
+
   State(
       bool microBattles = false,
       std::set<BW::UnitType> onlyConsiderTypes = std::set<BW::UnitType>());

--- a/lua/state_lua.h
+++ b/lua/state_lua.h
@@ -18,6 +18,10 @@ extern "C" {
 
 int newState(lua_State* L);
 int pushState(lua_State* L, torchcraft::State* s = nullptr);
+int pushUpdatesState(
+    lua_State* L,
+    std::vector<std::string>& updates,
+    int index = -1);
 int freeState(lua_State* L);
 int gcState(lua_State* L);
 int indexState(lua_State* L);
@@ -25,10 +29,6 @@ int newindexState(lua_State* L);
 int resetState(lua_State* L);
 int totableState(lua_State* L);
 int setconsiderState(lua_State* L);
-int pushUpdatesState(
-    lua_State* L,
-    std::vector<std::string>& updates,
-    int index = -1);
 
 const struct luaL_Reg state_m[] = {
     {"__gc", gcState},


### PR DESCRIPTION
This moves the logic previously implemented as a side-effect of
pushUpdatesState() to a local helper function, updateUserValueAndPush().
Pre-defined user values are now computed whenever a uservalue entry is
requested. Caching is controlled by a new total update counter in State.