### PR TITLE
Reset battle_frame_count in MatchEnd, so it resets properly when doing a quit

### DIFF
--- a/BWEnv/src/controller.cc
+++ b/BWEnv/src/controller.cc
@@ -1034,6 +1034,7 @@ void Controller::handleEvents()
     case BWAPI::EventType::MatchEnd:
       this->game_ended = true;
       this->is_winner = e.isWinner();
+      this->battle_frame_count = 0;
       break;
     default:
       break;


### PR DESCRIPTION
With a DLL, this happens because the module is reloaded, but with a client/openbw this seems to be necessary.