### PR TITLE
Fixing Train command in simple_dll

### DIFF
--- a/examples/cpp/simple_dll.cpp
+++ b/examples/cpp/simple_dll.cpp
@@ -171,6 +171,9 @@ void playGame(std::shared_ptr<tc::Client> cl, int* totalBattles) {
               tc::BW::Command::CommandUnit,
               unit.id,
               tc::BW::UnitCommandType::Train,
+              0,
+              0,
+              0,
               tc::BW::UnitType::Terran_Marine);
         }
       } else if (tc::BW::isWorker(utype)) {

--- a/examples/simple_dll.lua
+++ b/examples/simple_dll.lua
@@ -136,7 +136,7 @@ while total_battles < 40 do
                         if ut.type == tc.unittypes.Terran_Barracks then
                             table.insert(actions,
                             tc.command(tc.command_unit, uid, tc.cmd.Train,
-                            tc.unittypes.Terran_Marine))
+                            0, 0, 0, tc.unittypes.Terran_Marine))
                         end
                     elseif tc:isworker(ut.type) then
                         if tc.state.resources_myself.ore >= 150


### PR DESCRIPTION
The unittype is always given as the last argument. This script currently works, but only because marines are unittype 0. It could be confusing to newcomers.