### PR TITLE
Python bugfixes / improvements

### DIFF
--- a/py/pyconstants.cpp
+++ b/py/pyconstants.cpp
@@ -17,7 +17,7 @@ void setEnumDict(py::module& module, const std::string& name, F map) {
     dict[py::int_(v._to_integral())] = py::str(str);
     mod.attr(py::str(str)) = py::int_(v._to_integral());
   }
-  module.attr("_dict") = dict;
+  mod.attr("_dict") = dict;
 }
 
 template <typename Enum>

--- a/py/pyreplayer.cpp
+++ b/py/pyreplayer.cpp
@@ -233,6 +233,7 @@ void init_replayer(py::module& m) {
           py::arg("compressed") = true);
 
   m_sub.def("load", [](const std::string& path) {
+    py::gil_scoped_release release;
     auto rep = new Replayer();
     rep->load(path);
     return rep;

--- a/py/pyreplayer.cpp
+++ b/py/pyreplayer.cpp
@@ -197,8 +197,8 @@ void init_replayer(py::module& m) {
             // TODO Figure out how to return a THTensor... Copying the code
             // avoids an extra copy operation
             auto map = self->getRawMap();
-            auto h = THByteTensor_size(map, 0);
-            auto w = THByteTensor_size(map, 1);
+            auto h = (uint64_t)THByteTensor_size(map, 0);
+            auto w = (uint64_t)THByteTensor_size(map, 1);
             auto walkability = py::array_t<uint8_t>({h, w});
             auto ground_height = py::array_t<uint8_t>({h, w});
             auto buildability = py::array_t<uint8_t>({h, w});


### PR DESCRIPTION
- replayer.load can be multithreaded
- Removed compiler warning about types by an explicit type conversion
- Python constants now correctly have a ._dict that has an inverse mapping.