### PR TITLE
Python: Client.state() needs to return a reference

### DIFF
--- a/py/pyclient.cpp
+++ b/py/pyclient.cpp
@@ -76,5 +76,5 @@ void init_client(py::module& torchcraft) {
           })
       .def("poll", &Client::poll)
       .def("error", &Client::error)
-      .def("state", &Client::state);
+      .def("state", &Client::state, py::return_value_policy::reference);
 }


### PR DESCRIPTION
The client owns its state object, so the state's lifetime is tied to the
lifetime of the client. Return a reference via pybind to prevent potential
use-after-free issues if the Python state object outlives its client.