### PR TITLE
Add OpenBW create / kill units interface

### DIFF
--- a/BWEnv/CMakeLists.txt
+++ b/BWEnv/CMakeLists.txt
@@ -6,9 +6,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_path(OPENBW_DIR bwgame.h mini-openbwapi
   PATHS
   ENV OPENBW_DIR
-  ../../../tsc-bw
-  ../../tsc-bw
-  ../tsc-bw
+  ../../../openbw
+  ../../openbw
+  ../openbw
 )
 
 if (NOT OPENBW_DIR)

--- a/BWEnv/include/controller.h
+++ b/BWEnv/include/controller.h
@@ -54,7 +54,7 @@ enum OBWCommands {
   KILL_UNIT,
   // four args
   SPAWN_UNIT,
-}
+};
 
 enum CommandStatus : int8_t {
   SUCCESS = 0,

--- a/BWEnv/include/controller.h
+++ b/BWEnv/include/controller.h
@@ -36,6 +36,7 @@ enum Commands {
   COMMAND_UNIT, COMMAND_UNIT_PROTECTED,
   // variable arguments
   COMMAND_USER,
+  COMMAND_OPENBW,
   // BAWPI drawing routins
   DRAW_LINE,          // x1, y1, x2, y2, color
   DRAW_UNIT_LINE,     // uid1, uid2, color
@@ -47,6 +48,13 @@ enum Commands {
   // last command id
   COMMAND_END
 };
+
+enum OBWCommands {
+  // two args
+  KILL_UNIT,
+  // four args
+  SPAWN_UNIT,
+}
 
 enum CommandStatus : int8_t {
   SUCCESS = 0,
@@ -60,6 +68,9 @@ enum CommandStatus : int8_t {
   TOO_MANY_COMMANDS = -4,
   INVALID_UNIT = -5,
   PROTECTED = -6,
+  OPENBW_NOT_IN_USE = -7,
+  INVALID_PLAYER = -8,
+  OPENBW_UNSUCCESSFUL_COMMAND = -9,  // TODO reconsider whether we want this
 };
 
 class Controller
@@ -75,6 +86,7 @@ public:
   int8_t handleCommand(int command, const std::vector<int>& args,
     const std::string& str);
   int8_t handleUserCommand(int command, const std::vector<int>& args);
+  int8_t handleOpenBWCommand(int command, const std::vector<int>& args);
   void setCommandsStatus(std::vector<int8_t> status);
   BWAPI::Position getPositionFromWalkTiles(int x, int y);
   BWAPI::TilePosition getTilePositionFromWalkTiles(int x, int y);

--- a/BWEnv/include/zmq_server.h
+++ b/BWEnv/include/zmq_server.h
@@ -18,7 +18,7 @@ class Controller;
 
 class ZMQ_server
 {
-  static const int protocol_version = 18;
+  static const int protocol_version = 19;
   static const int max_commands = 400; // maximum number of commands per frame
   static const int starting_port = 11111;
   static const int max_instances = 1000;

--- a/BWEnv/src/controller.cc
+++ b/BWEnv/src/controller.cc
@@ -456,22 +456,22 @@ int8_t Controller::handleCommand(int command, const std::vector<int>& args,
       return handleOpenBWCommand(type, user_args);
     }
     }
-    Utils::bwlog(output_log, "Invalid command: %d", command);
-    return CommandStatus::UNKNOWN_COMMAND;
   }
+  Utils::bwlog(output_log, "Invalid command: %d", command);
+  return CommandStatus::UNKNOWN_COMMAND;
 }
 
-int8_t Controller::handleOpenBWCommand(int, command, const std::vector<int>& args)
+int8_t Controller::handleOpenBWCommand(int command, const std::vector<int>& args)
 {
-  #ifndef OPENBW_BWAPI
-  status = CommandStatus::OPENBW_NOT_IN_USE;
-  return status;
-  #endif
+  int8_t status = CommandStatus::OPENBW_NOT_IN_USE;
 
+  #ifndef OPENBW_BWAPI
+  return status;
+  #else
   switch (command)
   {
   case OBWCommands::KILL_UNIT: {
-    auto u = BWAPI::Broodwar->getUnit(args[2])
+    auto u = BWAPI::Broodwar->getUnit(args[2]);
     if (u == nullptr)
     {
       status = CommandStatus::INVALID_UNIT;
@@ -499,6 +499,7 @@ int8_t Controller::handleOpenBWCommand(int, command, const std::vector<int>& arg
   }
   Utils::bwlog(output_log, "Invalid command: %d", command);
   return CommandStatus::UNKNOWN_COMMAND;
+  #endif
 }
 
 int8_t Controller::handleUserCommand(int command, const std::vector<int>& args)

--- a/BWEnv/src/controller.cc
+++ b/BWEnv/src/controller.cc
@@ -435,6 +435,12 @@ int8_t Controller::handleCommand(int command, const std::vector<int>& args,
       return CommandStatus::SUCCESS;
     }
     case Commands::COMMAND_USER: {
+      static std::unordered_map<int, int> argcount = {
+        {UserCommands::MOVE_SCREEN_UP, 2}, {UserCommands::MOVE_SCREEN_DOWN, 2},
+        {UserCommands::MOVE_SCREEN_LEFT, 2}, {UserCommands::MOVE_SCREEN_RIGHT, 2},
+        {UserCommands::MOVE_SCREEN_TO_POS, 3}, {UserCommands::RIGHT_CLICK, 5},
+      };
+      if (!check_args(argcount[command])) return status;
       auto type = args[0];
       auto second = args.begin() + 1;
       auto last = args.end();
@@ -499,50 +505,27 @@ int8_t Controller::handleOpenBWCommand(int command, const std::vector<int>& args
 
 int8_t Controller::handleUserCommand(int command, const std::vector<int>& args)
 {
-  int8_t status = CommandStatus::SUCCESS;
-  auto check_args = [&](uint32_t n) {
-    if (args.size() < n) {
-      Utils::bwlog(output_log, "Missing arguments: expected %d, got %d", n, args.size());
-      status = CommandStatus::MISSING_ARGUMENTS;
-      return false;
-    }
-    return true;
-  };
-
-  // one argument
-  if (command <= UserCommands::MOVE_SCREEN_RIGHT)
+  switch (command)
   {
-    if (!check_args(1)) return status;
-    switch (command)
-    {
-    case UserCommands::MOVE_SCREEN_UP:
-      user_actions::moveScreenUp(args[0]);
-      return CommandStatus::SUCCESS;
-    case UserCommands::MOVE_SCREEN_DOWN:
-      user_actions::moveScreenDown(args[0]);
-      return CommandStatus::SUCCESS;
-    case UserCommands::MOVE_SCREEN_LEFT:
-      user_actions::moveScreenLeft(args[0]);
-      return CommandStatus::SUCCESS;
-    case UserCommands::MOVE_SCREEN_RIGHT:
-      user_actions::moveScreenRight(args[0]);
-      return CommandStatus::SUCCESS;
-    }
-  }
-  else if (command < UserCommands::USER_COMMAND_END)
-  {
-    switch (command)
-    {
-    case UserCommands::MOVE_SCREEN_TO_POS:
-      if (!check_args(2)) return status;
-      user_actions::moveScreenToPos(args[0], args[1]);
-      return CommandStatus::SUCCESS;
-    case UserCommands::RIGHT_CLICK:
-      if (!check_args(4)) return status;
-      user_actions::rightClickPos(args[0], args[1], args[2],
-        args[3] == 0 ? false : true);
-      return CommandStatus::SUCCESS;
-    }
+  case UserCommands::MOVE_SCREEN_UP:
+    user_actions::moveScreenUp(args[0]);
+    return CommandStatus::SUCCESS;
+  case UserCommands::MOVE_SCREEN_DOWN:
+    user_actions::moveScreenDown(args[0]);
+    return CommandStatus::SUCCESS;
+  case UserCommands::MOVE_SCREEN_LEFT:
+    user_actions::moveScreenLeft(args[0]);
+    return CommandStatus::SUCCESS;
+  case UserCommands::MOVE_SCREEN_RIGHT:
+    user_actions::moveScreenRight(args[0]);
+    return CommandStatus::SUCCESS;
+  case UserCommands::MOVE_SCREEN_TO_POS:
+    user_actions::moveScreenToPos(args[0], args[1]);
+    return CommandStatus::SUCCESS;
+  case UserCommands::RIGHT_CLICK:
+    user_actions::rightClickPos(args[0], args[1], args[2],
+                                args[3] == 0 ? false : true);
+    return CommandStatus::SUCCESS;
   }
   Utils::bwlog(output_log, "Invalid user command: %d", command);
   return CommandStatus::UNKNOWN_COMMAND;

--- a/BWEnv/src/controller.cc
+++ b/BWEnv/src/controller.cc
@@ -464,14 +464,13 @@ int8_t Controller::handleCommand(int command, const std::vector<int>& args,
 int8_t Controller::handleOpenBWCommand(int command, const std::vector<int>& args)
 {
   int8_t status = CommandStatus::OPENBW_NOT_IN_USE;
-
   #ifndef OPENBW_BWAPI
   return status;
   #else
   switch (command)
   {
   case OBWCommands::KILL_UNIT: {
-    auto u = BWAPI::Broodwar->getUnit(args[2]);
+    auto u = BWAPI::Broodwar->getUnit(args[0]);
     if (u == nullptr)
     {
       status = CommandStatus::INVALID_UNIT;

--- a/BWEnv/src/controller.cc
+++ b/BWEnv/src/controller.cc
@@ -463,9 +463,8 @@ int8_t Controller::handleCommand(int command, const std::vector<int>& args,
 
 int8_t Controller::handleOpenBWCommand(int command, const std::vector<int>& args)
 {
-  int8_t status = CommandStatus::OPENBW_NOT_IN_USE;
   #ifndef OPENBW_BWAPI
-  return status;
+  return CommandStatus::OPENBW_NOT_IN_USE;
   #else
   switch (command)
   {
@@ -473,8 +472,7 @@ int8_t Controller::handleOpenBWCommand(int command, const std::vector<int>& args
     auto u = BWAPI::Broodwar->getUnit(args[0]);
     if (u == nullptr)
     {
-      status = CommandStatus::INVALID_UNIT;
-      return false;
+      return CommandStatus::INVALID_UNIT;
     }
     BWAPI::Broodwar->killUnit(u);
     return CommandStatus::SUCCESS;
@@ -483,15 +481,13 @@ int8_t Controller::handleOpenBWCommand(int command, const std::vector<int>& args
     auto p = BWAPI::Broodwar->getPlayer(args[0]);
     if (p == nullptr)
       {
-        status = CommandStatus::INVALID_PLAYER;
-        return false;
+        return CommandStatus::INVALID_PLAYER;
       }
     auto pos = BWAPI::Position(args[2], args[3]);
     auto u = BWAPI::Broodwar->createUnit(p, args[1], pos);
     if (u == nullptr)
       {
-        status = CommandStatus::OPENBW_UNSUCCESSFUL_COMMAND;
-        return false;
+        return CommandStatus::OPENBW_UNSUCCESSFUL_COMMAND;
       }
     return CommandStatus::SUCCESS;
   }

--- a/client/client.cpp
+++ b/client/client.cpp
@@ -40,7 +40,7 @@ void buildHandshakeMessage(
     const torchcraft::Client::Options& opts,
     const std::string* uid = nullptr) {
   torchcraft::fbs::HandshakeClientT hsc;
-  hsc.protocol = 18;
+  hsc.protocol = 19;
   hsc.map = opts.initial_map;
   if (opts.window_size[0] >= 0) {
     hsc.window_size.reset(

--- a/docs/user/openbw.md
+++ b/docs/user/openbw.md
@@ -13,13 +13,13 @@ These can be installed on ubuntu with apt install libczmq-dev libsdl2-dev
 ### Compile
 
 ```
-git clone https://github.com/TorchCraft/TorchCraft.git
-git clone https://github.com/tscmoo/tsc-bw.git
-cd TorchCraft/BWEnv
-mkdir build
-cd build
-OPENBW_DIR=../../../tsc-bw cmake .. -DOPENBW_ENABLE_UI=ON
-make
+$ git clone https://github.com/TorchCraft/TorchCraft.git
+$ git clone https://github.com/openbw/openbw.git
+$ cd TorchCraft/BWEnv
+$ mkdir build
+$ cd build
+$ OPENBW_DIR=../../../openbw cmake .. -DOPENBW_ENABLE_UI=ON
+$ make
 ```
 This should build a bwenv executable. If you omit the -DOPENBW_ENABLE_UI=ON part, then openbw will be built with no graphics support, and SDL2 will not be required.
 Otherwise, to get any on screen visualization TorchCraft needs to send the set_gui command, eg `tc.command(tc.set_gui, 1)`. The examples do this. If it is omitted, or if `tc.command(tc.set_gui, 0)` is run then nothing will appear on screen.

--- a/examples/py/create_kill.py
+++ b/examples/py/create_kill.py
@@ -1,0 +1,98 @@
+import argparse
+import random
+
+import torchcraft as tc
+import torchcraft.Constants as tcc
+
+parser = argparse.ArgumentParser(
+    description='Plays simple micro battles with an attack closest heuristic')
+parser.add_argument(
+    '-t', '--hostname', type=str, help='Hostname where SC is running')
+parser.add_argument('-p', '--port', default=11111, help="Port to use")
+parser.add_argument('-d', '--debug', default=0, type=int, help="Debug level")
+
+args = parser.parse_args()
+
+DEBUG = args.debug
+
+
+def create_units(player, quantity, x=100, y=100, u_type=0):
+    commands = []
+    for i in range(quantity):
+        command = [
+            tcc.command_openbw,
+            tcc.openbwcommandtypes.SpawnUnit,
+            player,
+            u_type,
+            x,
+            y,
+        ]
+        commands.append(command)
+    return commands
+
+
+def kill_units(units, quantity):
+    commands = []
+    random.shuffle(units)
+    for i in range(quantity):
+        u = units[i]
+        command = [
+            tcc.command_openbw,
+            tcc.openbwcommandtypes.KillUnit,
+            u.id,
+        ]
+        commands.append(command)
+    return commands
+
+
+skip_frames = 1
+nrestarts = 0
+total_battles = 0
+max_add_quantity = 20
+tries = 5
+
+cl = tc.Client()
+cl.connect(args.hostname, args.port)
+state = cl.init(micro_battles=True)
+cl.send([
+    [tcc.set_combine_frames, skip_frames],
+    [tcc.set_speed, 0],
+    [tcc.set_gui, 1],
+    [tcc.set_cmd_optim, 1],
+])
+
+for i in range(tries):
+    print("# try: {}".format(i))
+    unit_add_quantity = random.randint(1, max_add_quantity)
+    while state.game_ended or state.waiting_for_restart:
+        cl.send([])
+        state = cl.recv()
+
+    initial_lens = [len(state.units[0]), len(state.units[1])]
+
+    print("Current size: {}".format(initial_lens))
+    command = create_units(0, unit_add_quantity)
+    command += create_units(1, unit_add_quantity)
+
+    print("Creating {} units...".format(unit_add_quantity))
+    cl.send(command)
+    state = cl.recv()
+
+    assert (len(state.units[0]) == initial_lens[0] + unit_add_quantity)
+    assert (len(state.units[1]) == initial_lens[1] + unit_add_quantity)
+    print(
+        "Current size: {}".format([len(state.units[0]), len(state.units[1])]))
+
+    command = kill_units(state.units[0], unit_add_quantity)
+    command += kill_units(state.units[1], unit_add_quantity)
+
+    print("Killing {} units...".format(unit_add_quantity))
+    cl.send(command)
+    state = cl.recv()
+
+    assert (len(state.units[0]) == initial_lens[0])
+    assert (len(state.units[1]) == initial_lens[1])
+    print("Current size: {}".format(initial_lens))
+
+cl.close()
+print("All good.")

--- a/include/constants.h
+++ b/include/constants.h
@@ -56,7 +56,7 @@ BETTER_ENUM(
     // arguments: (command, args)
     // For documentation about args, see usercommandtypes
     CommandUser = 16,
-		CommandOpenBW = 17,
+		CommandOpenbw = 17,
 
     // BWAPI drawing routines
     DrawLine = 18, //  x1, y1, x2, y2, color index

--- a/include/constants.h
+++ b/include/constants.h
@@ -56,7 +56,7 @@ BETTER_ENUM(
     // arguments: (command, args)
     // For documentation about args, see usercommandtypes
     CommandUser = 16,
-		CommandOpenbw = 17,
+    CommandOpenbw = 17,
 
     // BWAPI drawing routines
     DrawLine = 18, //  x1, y1, x2, y2, color index

--- a/include/constants.h
+++ b/include/constants.h
@@ -56,17 +56,28 @@ BETTER_ENUM(
     // arguments: (command, args)
     // For documentation about args, see usercommandtypes
     CommandUser = 16,
+		CommandOpenBW = 17,
 
     // BWAPI drawing routines
-    DrawLine = 17, //  x1, y1, x2, y2, color index
-    DrawUnitLine = 18, // uid1, uid2, color index
-    DrawUnitPosLine = 19, // uid, x2, y2, color index
-    DrawCircle = 20, //  x, y, radius, color index
-    DrawUnitCircle = 21, // uid, radius, color index
-    DrawText = 22, // x, y plus text arg
-    DrawTextScreen = 23, // x, y plus text arg
+    DrawLine = 18, //  x1, y1, x2, y2, color index
+    DrawUnitLine = 19, // uid1, uid2, color index
+    DrawUnitPosLine = 20, // uid, x2, y2, color index
+    DrawCircle = 21, //  x, y, radius, color index
+    DrawUnitCircle = 22, // uid, radius, color index
+    DrawText = 23, // x, y plus text arg
+    DrawTextScreen = 24, // x, y plus text arg
 
     MAX)
+
+BETTER_ENUM(
+				OpenBWCommandType,
+				int,
+				// two args
+				KillUnit = 0, // uid
+				// four args
+				SpawnUnit = 1, // playerid, type, x, y
+
+				OPENBW_COMMAND_END = 2)
 
 BETTER_ENUM(
     UserCommandType,

--- a/include/constants.h
+++ b/include/constants.h
@@ -70,14 +70,14 @@ BETTER_ENUM(
     MAX)
 
 BETTER_ENUM(
-				OpenBWCommandType,
-				int,
-				// two args
-				KillUnit = 0, // uid
-				// four args
-				SpawnUnit = 1, // playerid, type, x, y
+    OpenBWCommandType,
+    int,
+    // two args
+    KillUnit = 0, // uid
+    // four args
+    SpawnUnit = 1, // playerid, type, x, y
 
-				OPENBW_COMMAND_END = 2)
+    OPENBW_COMMAND_END = 2)
 
 BETTER_ENUM(
     UserCommandType,

--- a/lua/constants_lua.cpp
+++ b/lua/constants_lua.cpp
@@ -302,6 +302,8 @@ void registerConstants(lua_State* L, int index) {
 
   pushTable<BW::Command>(L, fromCamelCaseToLower);
   lua_setfield(L, -2, "commands");
+  pushTable<BW::OpenBWCommandType>(L);
+  lua_setfield(L, -2, "openbwcommandtypes");
   pushTable<BW::UserCommandType>(L);
   lua_setfield(L, -2, "usercommandtypes");
   pushTable<BW::UnitCommandType>(L);

--- a/py/pyconstants.cpp
+++ b/py/pyconstants.cpp
@@ -53,6 +53,7 @@ void init_constants(py::module& torchcraft) {
         v._to_integral();
   setEnumDict<BW::UnitCommandType>(constants, "unitcommandtypes");
   setEnumDict<BW::OpenBWCommandType>(constants, "openbwcommandtypes");
+  setEnumDict<BW::UserCommandType>(constants, "usercommandtypes");
   setEnumDict<BW::Order>(constants, "orders");
   setEnumDict<BW::TechType>(constants, "techtypes");
   setEnumDict<BW::UnitType>(constants, "unittypes");

--- a/py/pyconstants.cpp
+++ b/py/pyconstants.cpp
@@ -52,6 +52,7 @@ void init_constants(py::module& torchcraft) {
     constants.attr(fromCamelCaseToLower(v._to_string()).c_str()) =
         v._to_integral();
   setEnumDict<BW::UnitCommandType>(constants, "unitcommandtypes");
+  setEnumDict<BW::OpenBWCommandType>(constants, "openbwcommandtypes");
   setEnumDict<BW::Order>(constants, "orders");
   setEnumDict<BW::TechType>(constants, "techtypes");
   setEnumDict<BW::UnitType>(constants, "unittypes");


### PR DESCRIPTION
Untested, since `tsc-bw` is currently not compiling on clang. Waiting on @tscmoo to unbreak that before merging this into develop.

Also adds user commands to the python client.

Note: I don't want to add the rest of the new API to this PR, as they warrant more discussion.