### PR TITLE
Fix/update bwenv cmakelists

### DIFF
--- a/BWEnv/CMakeLists.txt
+++ b/BWEnv/CMakeLists.txt
@@ -1,31 +1,42 @@
 cmake_minimum_required(VERSION 3.1)
+project(BWEnv)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_path(OPENBW_DIR bwgame.h mini-openbwapi
-  PATHS
-  ENV OPENBW_DIR
-  ../../../openbw
-  ../../openbw
-  ../openbw
-)
+set(CMAKE_SHARED_LIBRARY_PREFIX "")
 
-if (NOT OPENBW_DIR)
-  message(FATAL_ERROR "Couldn't find openbw. Specify the path to it with OPENBW_DIR environment variable (git clone https://github.com/tscmoo/tsc-bw)")
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+
+if (USE_MINI_OPENBWAPI)
+  find_path(OPENBW_DIR bwgame.h mini-openbwapi
+    PATHS
+    ENV OPENBW_DIR
+    ../../../openbw
+    ../../openbw
+    ../openbw
+  )
+  
+  if (NOT OPENBW_DIR)
+    message(FATAL_ERROR "Couldn't find openbw. Specify the path to it with OPENBW_DIR environment variable")
+  endif()
+  
+  add_subdirectory(${OPENBW_DIR}/mini-openbwapi mini-openbwapi)
+  
+  set(BWAPI_INCLUDE_DIRS ${OPENBW_DIR}/mini-openbwapi)
+  set(BWAPI_LIBRARIES mini-openbwapi)
+else()
+  find_package(BWAPI REQUIRED)
 endif()
-
-add_subdirectory(${OPENBW_DIR}/mini-openbwapi mini-openbwapi)
 
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${CMAKE_CURRENT_SOURCE_DIR}/fbs
   ${CMAKE_CURRENT_SOURCE_DIR}/../include
-  ${OPENBW_DIR}/mini-openbwapi
+  ${BWAPI_INCLUDE_DIRS}
 )
 
-add_executable(bwenv
-  src/main.cc
+add_library(BWEnvObj OBJECT
   src/config_manager.cc
   src/controller.cc
   src/user_actions.cc
@@ -34,7 +45,27 @@ add_executable(bwenv
   ../replayer/frame.cpp
 )
 
-target_link_libraries(bwenv
+set_property(TARGET BWEnvObj PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+if (NOT USE_MINI_OPENBWAPI)
+  add_library(BWEnv SHARED
+    src/dll.cc
+    src/module.cc
+    $<TARGET_OBJECTS:BWEnvObj>
+  )
+  
+  target_link_libraries(BWEnv
+    czmq
+    ${BWAPI_LIBRARIES}
+  )
+endif()
+
+add_executable(BWEnvClient
+  src/main.cc
+  $<TARGET_OBJECTS:BWEnvObj>
+)
+
+target_link_libraries(BWEnvClient
   czmq
-  mini-openbwapi
+  ${BWAPI_LIBRARIES}
 )

--- a/BWEnv/FindBWAPI.cmake
+++ b/BWEnv/FindBWAPI.cmake
@@ -1,0 +1,16 @@
+# This defines
+# BWAPI_FOUND - if BWAPI was found
+# BWAPI_INCLUDE_DIRS - include directories
+# BWAPI_LIBRARIES - libraries to link to
+
+find_path(BWAPI_INCLUDE_DIR BWAPI.h PATHS ${BWAPI_DIR} ENV BWAPI_DIR PATH_SUFFIXES include)
+find_library(BWAPI_LIBRARY BWAPILIB PATHS ${BWAPI_DIR} ENV BWAPI_DIR PATH_SUFFIXES lib)
+find_library(BWAPIClient_LIBRARY BWAPIClient PATHS ${BWAPI_DIR} ENV BWAPI_DIR PATH_SUFFIXES lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(BWAPI DEFAULT_MSG BWAPI_LIBRARY BWAPI_INCLUDE_DIR)
+
+mark_as_advanced(BWAPI_INCLUDE_DIR BWAPI_LIBRARY)
+
+set(BWAPI_INCLUDE_DIRS ${BWAPI_INCLUDE_DIR})
+set(BWAPI_LIBRARIES ${BWAPI_LIBRARY} ${BWAPIClient_LIBRARY})

--- a/BWEnv/src/dll.cc
+++ b/BWEnv/src/dll.cc
@@ -11,7 +11,15 @@
 
 #include "module.h"
 
-extern "C" __declspec(dllexport) void gameInit(BWAPI::Game* game) { BWAPI::BroodwarPtr = game; }
+#ifdef _WIN32
+#include <windows.h>
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT
+#endif
+
+extern "C" DLLEXPORT void gameInit(BWAPI::Game* game) { BWAPI::BroodwarPtr = game; }
+#ifdef _WIN32
 BOOL APIENTRY DllMain(HANDLE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {
   switch (ul_reason_for_call)
@@ -23,8 +31,9 @@ BOOL APIENTRY DllMain(HANDLE hModule, DWORD ul_reason_for_call, LPVOID lpReserve
   }
   return TRUE;
 }
+#endif
 
-extern "C" __declspec(dllexport) BWAPI::AIModule* newAIModule()
+extern "C" DLLEXPORT BWAPI::AIModule* newAIModule()
 {
   return new Module();
 }


### PR DESCRIPTION
The previous CMakeLists.txt only allowed to compile with mini-openbwapi, which is soon obsolete.
This allows to compile with the new openbw bwapi and regular bwapi on windows too.
mini-openbwapi can still be used if USE_MINI_OPENBWAPI option is enabled.