### PR TITLE
BWEnv: support IPv6 on non-Windows systems

### DIFF
--- a/BWEnv/src/zmq_server.cc
+++ b/BWEnv/src/zmq_server.cc
@@ -78,6 +78,8 @@ void ZMQ_server::connect()
       if (setsockopt(zsock_fd(this->server_sock), SOL_SOCKET, SO_REUSEADDR, (char *)&reuse, sizeof(reuse)) != 0) {
         std::cout << "SO_REUSEADDR setsockopt failed with " << WSAGetLastError() << std::endl;
       }
+#else
+      zsock_set_ipv6(this->server_sock, 1);
 #endif
       success = zsock_bind(this->server_sock, "%s", url.str().c_str());
       std::this_thread::sleep_for(std::chrono::seconds(1));


### PR DESCRIPTION
This enables connections to BWEnv with both IPv4 and IPv6. If restricted to IPv4
only, there's an issue that appears on some non-Windows systems that prevents
establishing a connectiong with a TC client (which also supports both IPv4 and
IPv67).

I'll leave the Windows setup as is since it's functional it's a little bit of a
hassle for me to test IPv6 connectivity there.