### PR TITLE
Remove two hours time limit on TC server

### DIFF
--- a/BWEnv/include/controller.h
+++ b/BWEnv/include/controller.h
@@ -148,7 +148,6 @@ class Controller {
   replayer::Frame* prev_sent_frame = nullptr; // For frame diffs
   int battle_frame_count = 0;
   int frameskips = 1;
-  bool too_long_play_ = false;
   bool exit_process_ = false;
   bool with_image_ = false;
   std::vector<std::pair<std::vector<int>, std::string>> draw_cmds_;

--- a/BWEnv/src/controller.cc
+++ b/BWEnv/src/controller.cc
@@ -131,7 +131,7 @@ void Controller::loop() {
       if (exit_process_)
         break;
 
-      if (game_ended || too_long_play_) {
+      if (game_ended) {
         endGame();
         break;
       }
@@ -683,10 +683,6 @@ void Controller::onFrame() {
   } catch (std::exception& e) {
     Utils::bwlog(output_log, "Error drawing client annotations: %s", e.what());
   }
-
-  // Called once every game frame
-  // if more than ~2 hours worth of SC for the game, reboot the game
-  too_long_play_ = Utils::checkTimeInGame();
 
   // check if the Proxy Bot is connected
   if (!this->zmq_server->server_sock_connected) {

--- a/examples/simple_dll.lua
+++ b/examples/simple_dll.lua
@@ -8,7 +8,6 @@
 
 -- attacks the closest units, th simple_dll.lua [-t $hostname] [-p $port]
 local DEBUG = 0 -- can take values 0, 1, 2 (from no output to most verbose)
-local MICRO_MODE = true -- set to false for normal maps!
 require 'torch'
 torch.setdefaulttensortype('torch.FloatTensor')
 require 'sys'
@@ -18,6 +17,7 @@ Baselines for Starcraft
     -t,--hostname       (default "")    Give hostname / ip pointing to VM
     -h,--heuristic      (default "wc")  Check comments for list of heuristics
     -p,--port           (default 11111) Port for torchcraft. Do 0 to grab vm from cloud
+    -m,--micro                          Whether we're doing a micro map, defaults to false
 ]]
 
 local skip_frames = 7
@@ -57,7 +57,7 @@ local total_battles = 0
 local maps = {'Maps/BroodWar/micro/dragoons_zealots.scm',
               'Maps/BroodWar/micro/m5v5_c_far.scm'}
 
-tc.micro_battles = MICRO_MODE
+tc.micro_battles = args.micro
 local nrestarts = -1
 
 while total_battles < 40 do


### PR DESCRIPTION
Ran simple_dll for 270k frames, or a bit over 3 hours. #170 