### PR TITLE
Changes unit->buildTechUpgradeType to never return -1

### DIFF
--- a/BWEnv/src/controller.cc
+++ b/BWEnv/src/controller.cc
@@ -965,9 +965,6 @@ void Controller::addUnit(
     buildTechUpgradeType = u->getTech().getID();
     if (buildTechUpgradeType == BWAPI::TechTypes::None.getID()) {
       buildTechUpgradeType = u->getUpgrade().getID();
-      if (buildTechUpgradeType == BWAPI::UpgradeTypes::None.getID()) {
-        buildTechUpgradeType = -1;
-      }
     }
   }
 


### PR DESCRIPTION
buildTechUpgradeType returns BWAPI::UpgradeTypes::None.getID() instead of -1 when nothing matches.