### PR TITLE
Change argument order for getCreepAt()

### DIFF
--- a/examples/dump_replay.lua
+++ b/examples/dump_replay.lua
@@ -140,7 +140,7 @@ function write_creep_map(framenum, outname)
     mf:write("P2 " .. walkmap:size(2) .. " " .. walkmap:size(1) .. " " .. max .. "\n")
     for y = 1, ft.height do
       for x = 1, ft.width do
-        mf:write((f:getCreepAt(y, x) and 1 or 0) .. " ")
+        mf:write((f:getCreepAt(x, y) and 1 or 0) .. " ")
       end
       mf:write('\n')
     end

--- a/include/frame.h
+++ b/include/frame.h
@@ -463,7 +463,7 @@ class Frame : public RefCounted {
     is_terminal = next_frame.is_terminal;
   }
 
-  bool getCreepAt(uint32_t y, uint32_t x) {
+  bool getCreepAt(uint32_t x, uint32_t y) {
     auto ind = (y / 4) * (this->width / 4) + (x / 4); // Convert to buildtiles
     return (this->creep_map[ind / 8] >> (ind % 8)) & 1;
   }

--- a/lua/frame_lua.cpp
+++ b/lua/frame_lua.cpp
@@ -749,7 +749,7 @@ extern "C" int frameGetCreepAt(lua_State* L) {
   Frame* f = checkFrame(L);
   uint32_t y = luaL_checkint(L, 2);
   uint32_t x = luaL_checkint(L, 3);
-  lua_pushboolean(L, f->getCreepAt(y - 1, x - 1));
+  lua_pushboolean(L, f->getCreepAt(x - 1, y - 1));
   return 1;
 }
 


### PR DESCRIPTION
Pass x and then y for the sake of consistency.