### PR TITLE
Fix pack units for UMS maps

### DIFF
--- a/BWEnv/src/controller.cc
+++ b/BWEnv/src/controller.cc
@@ -895,6 +895,8 @@ void Controller::packMyUnits(replayer::Frame& f) {
 void Controller::packTheirUnits(
     replayer::Frame& f,
     BWAPI::PlayerInterface* player) {
+  if (player == nullptr)
+    return;
   for (auto& u : player->getUnits()) {
     if (u->getHitPoints() > 0) {
       addUnit(u, f, player); // TODO: only when the state changes


### PR DESCRIPTION
When in an UMS map and you cannot see your opponent's units, for some reason the Broodwar::getEnemy() is a nullptr sometimes.

This might just be in OpenBW @tscmoo 