### PR TITLE
Set is_winner correctly on game end when using a module.

### DIFF
--- a/BWEnv/include/controller.h
+++ b/BWEnv/include/controller.h
@@ -125,6 +125,7 @@ class Controller {
   void setMap(const std::string& relative_path);
   void setWindowSize(std::pair<int, int> size);
   void setWindowPos(const std::pair<int, int> size);
+  void setIsWinner(bool isWinner);
   std::ofstream output_log;
   std::unique_ptr<ZMQ_server> zmq_server;
   std::vector<int> deaths;

--- a/BWEnv/src/controller.cc
+++ b/BWEnv/src/controller.cc
@@ -1193,3 +1193,8 @@ void Controller::setWindowPos(const std::pair<int, int> pos) {
   Utils::overwriteConfig(sc_path_, "left", std::to_string(pos.first));
   Utils::overwriteConfig(sc_path_, "top", std::to_string(pos.second));
 }
+
+void Controller::setIsWinner(bool isWinner) {
+  this->is_winner = isWinner;
+}
+

--- a/BWEnv/src/module.cc
+++ b/BWEnv/src/module.cc
@@ -24,6 +24,7 @@ void Module::onStart() {
 }
 
 void Module::onEnd(bool isWinner) {
+  this->c_->setIsWinner(isWinner);
   this->c_->endGame();
 }
 


### PR DESCRIPTION
Previously it would only be set in client mode, thus with module (dll/so) the game would always report as a loss.