### PR TITLE
Update TorchCraft to BWAPI 4.2.0 / VS2017

### DIFF
--- a/BWEnv/VisualStudio/BWEnv.vcxproj
+++ b/BWEnv/VisualStudio/BWEnv.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -23,30 +23,31 @@
     <RootNamespace>BWEnv</RootNamespace>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>BWEnv</ProjectName>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DLL-Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DLL-Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <WholeProgramOptimization>false</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -147,7 +148,7 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>$(SolutionDir)/../include;$(SolutionDir)/../include/libzmq/include;$(SolutionDir)../../include/;$(SolutionDir)/../include/czmq/include;$(SolutionDir)/../fbs/;;$(BWAPI_DIR)/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(BWAPI_DIR)/include;$(SolutionDir)/../include;$(SolutionDir)/../include/libzmq/include;$(SolutionDir)../../include/;$(SolutionDir)/../include/czmq/include;$(SolutionDir)/../fbs/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;WIN32;NDEBUG;_WINDOWS;_USRDLL;BWENV_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>

--- a/BWEnv/include/controller.h
+++ b/BWEnv/include/controller.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include <vector>
 
+#define WIN32_LEAN_AND_MEAN
 #include <BWAPI.h>
 
 #include "config_manager.h"

--- a/BWEnv/include/module.h
+++ b/BWEnv/include/module.h
@@ -10,6 +10,7 @@
 #ifndef TORCHCRAFT_MODULE_H_
 #define TORCHCRAFT_MODULE_H_
 
+#define WIN32_LEAN_AND_MEAN
 #include <BWAPI.h>
 #include "controller.h"
 

--- a/BWEnv/include/zmq_server.h
+++ b/BWEnv/include/zmq_server.h
@@ -10,6 +10,8 @@
 #ifndef TORCHCRAFT_ZMQ_H_
 #define TORCHCRAFT_ZMQ_H_
 
+#define _WINSOCKAPI_
+#define WIN32_LEAN_AND_MEAN
 #include <czmq.h>
 #include "controller.h"
 #include "messages_generated.h"

--- a/BWEnv/src/controller.cc
+++ b/BWEnv/src/controller.cc
@@ -8,8 +8,8 @@
  */
 
 #include <thread>
-#define WIN32_LEAN_AND_MEAN
 
+#define WIN32_LEAN_AND_MEAN
 #include <BWAPI/Client.h>
 
 #include "controller.h"

--- a/BWEnv/src/dll.cc
+++ b/BWEnv/src/dll.cc
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#define _WINSOCKAPI_
+
+#define WIN32_LEAN_AND_MEAN
 #include <BWAPI.h>
 
 #include "module.h"

--- a/BWEnv/src/main.cc
+++ b/BWEnv/src/main.cc
@@ -7,6 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#define WIN32_LEAN_AND_MEAN
 #include <iostream>
 
 #include "controller.h"

--- a/BWEnv/src/user_actions.cc
+++ b/BWEnv/src/user_actions.cc
@@ -8,6 +8,8 @@
  */
 
 #include <stdexcept>
+
+#define WIN32_LEAN_AND_MEAN
 #include <BWAPI.h>
 
 #include "user_actions.h"

--- a/BWEnv/src/utils.cc
+++ b/BWEnv/src/utils.cc
@@ -13,8 +13,8 @@
 #include <regex>
 #include <iostream>
 
-#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
+#ifdef _WIN32
 #include <Windows.h>
 #endif
 

--- a/BWEnv/src/zmq_server.cc
+++ b/BWEnv/src/zmq_server.cc
@@ -7,11 +7,14 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#define WIN32_LEAN_AND_MEAN
 #include <BWAPI.h>
 #include <BWAPI/Client.h>
+
 #ifdef _WIN32
 #include <winsock2.h>
 #endif
+
 #include "zmq_server.h"
 #include "controller.h"
 #include <utils.h>

--- a/docker/cuda/Dockerfile
+++ b/docker/cuda/Dockerfile
@@ -82,7 +82,7 @@ RUN git clone https://github.com/TorchCraft/TorchCraft
 RUN cd ./TorchCraft; luarocks make *.rockspec
 
 RUN curl -L http://ftp.blizzard.com/pub/broodwar/patches/PC/BW-1161.exe -o /home/torchcraft/BW-1161.exe
-RUN curl -L https://github.com/bwapi/bwapi/releases/download/v4.1.2/BWAPI_412_Setup.exe -o /home/torchcraft/BWAPI_412_Setup.exe
+RUN curl -L https://github.com/bwapi/bwapi/releases/download/v4.2.0/BWAPI_420_Setup.exe -o /home/torchcraft/BWAPI_420_Setup.exe
 
 RUN chown -R torchcraft:torchcraft /root
 RUN chmod -R 777 /root

--- a/docker/no-cuda/Dockerfile
+++ b/docker/no-cuda/Dockerfile
@@ -82,7 +82,7 @@ RUN git clone https://github.com/TorchCraft/TorchCraft
 RUN cd ./TorchCraft; luarocks make *.rockspec
 
 RUN curl -L http://ftp.blizzard.com/pub/broodwar/patches/PC/BW-1161.exe -o /home/torchcraft/BW-1161.exe
-RUN curl -L https://github.com/bwapi/bwapi/releases/download/v4.1.2/BWAPI_412_Setup.exe -o /home/torchcraft/BWAPI_412_Setup.exe
+RUN curl -L https://github.com/bwapi/bwapi/releases/download/v4.2.0/BWAPI_420_Setup.exe -o /home/torchcraft/BWAPI_420_Setup.exe
 
 RUN chown -R torchcraft:torchcraft /root
 RUN chmod -R 777 /root

--- a/docs/user/bwapi_on_linux.md
+++ b/docs/user/bwapi_on_linux.md
@@ -32,8 +32,8 @@ Warning: Chaoslauncher was only tested to work on wine1.6. For most non-ubuntu d
     winetricks -q vcrun2013
     
     # Download latest release of BWAPI at https://github.com/bwapi/bwapi/releases
-    wget https://github.com/bwapi/bwapi/releases/download/v4.1.2/BWAPI_412_Setup.exe
-    wine BWAPI_412_Setup.exe
+    wget https://github.com/bwapi/bwapi/releases/download/v4.2.0/BWAPI_420_Setup.exe
+    wine BWAPI_420_Setup.exe
     # INSTALL THIS TO C:\StarCraft\BWAPI
     
     # Install TorchCraft


### PR DESCRIPTION
The only ugly hack here is the Winapi guards added before including `bwapi.h`, as VS2017 changes the way headers are imported, and as such it doesn't seem to be enough to define the variable in `Dll.cc` and `main.cc`.