### PR TITLE
Fix segfault on zero-length player names

### DIFF
--- a/BWEnv/src/controller.cc
+++ b/BWEnv/src/controller.cc
@@ -222,7 +222,7 @@ void Controller::setupHandshake() {
         std::make_unique<torchcraft::fbs::PlayerT>());
     handshake.players.back()->id = p->getID();
     handshake.players.back()->race = p->getRace().getID();
-    handshake.players.back()->name = p->getName().c_str();
+    handshake.players.back()->name = p->getName();
     handshake.players.back()->is_enemy = p->isEnemy(BWAPI::Broodwar->self());
   }
 

--- a/client/state.cpp
+++ b/client/state.cpp
@@ -210,7 +210,7 @@ std::vector<std::string> State::update(
       info.id = player->id();
       auto bwrace = BW::Race::_from_integral_nothrow(player->race());
       info.race = bwrace ? *bwrace : +BW::Race::Unknown;
-      info.name = player->name()->c_str();
+      info.name = player->name() ? player->name()->str() : "";
       info.is_enemy = player->is_enemy();
       player_info[info.id] = info;
     }


### PR DESCRIPTION
Also, no need to use c_str() to get the player name from BWAPI.