### PR TITLE
Non-blocking mode for BWEnv

### DIFF
--- a/BWEnv/include/controller.h
+++ b/BWEnv/include/controller.h
@@ -45,6 +45,8 @@ enum Commands {
   SET_COMBINE_FRAMES,
   SET_MAP,
   SET_MULTI,
+  SET_BLOCKING,
+  SET_MAX_FRAME_TIME_MS,
   // arguments are those of BWAPI::UnitCommand
   COMMAND_UNIT,
   COMMAND_UNIT_PROTECTED,
@@ -127,6 +129,8 @@ class Controller {
   void setWindowSize(std::pair<int, int> size);
   void setWindowPos(const std::pair<int, int> size);
   void setIsWinner(bool isWinner);
+  void clearPendingReceive();
+
   std::ofstream output_log;
   std::unique_ptr<ZMQ_server> zmq_server;
   std::vector<int> deaths;
@@ -145,13 +149,17 @@ class Controller {
   static const int pixelsPerTile = 32;
   static const int pixelsPerWalkTile = 8;
   bool logCommands = true;
-  int combine_frames = 1;
+  int min_combine_frames = 1;
+  int combined_frames = 0;
+  bool last_receive_ok = true;
   replayer::Frame* last_frame = nullptr;
   replayer::Frame* prev_sent_frame = nullptr; // For frame diffs
   int battle_frame_count = 0;
   int frameskips = 1;
   bool exit_process_ = false;
   bool with_image_ = false;
+  bool blocking_ = true;
+  int max_frame_time_ms_ = 50;
   std::vector<std::pair<std::vector<int>, std::string>> draw_cmds_;
   torchcraft::fbs::FrameT tcframe_;
 };

--- a/BWEnv/include/zmq_server.h
+++ b/BWEnv/include/zmq_server.h
@@ -42,7 +42,7 @@ public:
   void sendPlayerLeft(const torchcraft::fbs::PlayerLeftT *pl);
   void sendEndGame(const torchcraft::fbs::EndGameT *endgame);
   void sendError(const torchcraft::fbs::ErrorT *error);
-  void receiveMessage();
+  bool receiveMessage(int timeoutMs = -1);
   void handleReconnect(const torchcraft::fbs::HandshakeClient* handshake);
   std::vector<int8_t> handleCommands(const torchcraft::fbs::Commands* commands);
   int getPort();

--- a/BWEnv/src/module.cc
+++ b/BWEnv/src/module.cc
@@ -52,6 +52,7 @@ void Module::onPlayerLeft(BWAPI::Player player) {
 
   torchcraft::fbs::PlayerLeftT pl;
   pl.player_left = player->getName();
+  this->c_->clearPendingReceive();
   this->c_->zmq_server->sendPlayerLeft(&pl);
   this->c_->zmq_server->receiveMessage();
 }

--- a/include/constants.h
+++ b/include/constants.h
@@ -55,26 +55,28 @@ BETTER_ENUM(
     // you are guaranteed the map will be what you want.
     SetMap = 12,
     SetMulti = 13,
+    SetBlocking = 14,
+    SetMaxFrameTimeMs = 15,
 
     // arguments: (unit ID, command, target id, target x, target y, extra)
     // (x, y) are walktiles instead of pixels
     // otherwise this corresponds exactly to BWAPI::UnitCommand
-    CommandUnit = 14,
-    CommandUnitProtected = 15,
+    CommandUnit = 16,
+    CommandUnitProtected = 17,
 
     // arguments: (command, args)
     // For documentation about args, see usercommandtypes
-    CommandUser = 16,
-    CommandOpenbw = 17,
+    CommandUser = 18,
+    CommandOpenbw = 19,
 
     // BWAPI drawing routines
-    DrawLine = 18, //  x1, y1, x2, y2, color index
-    DrawUnitLine = 19, // uid1, uid2, color index
-    DrawUnitPosLine = 20, // uid, x2, y2, color index
-    DrawCircle = 21, //  x, y, radius, color index
-    DrawUnitCircle = 22, // uid, radius, color index
-    DrawText = 23, // x, y plus text arg
-    DrawTextScreen = 24, // x, y plus text arg
+    DrawLine = 20, //  x1, y1, x2, y2, color index
+    DrawUnitLine = 21, // uid1, uid2, color index
+    DrawUnitPosLine = 22, // uid, x2, y2, color index
+    DrawCircle = 23, //  x, y, radius, color index
+    DrawUnitCircle = 24, // uid, radius, color index
+    DrawText = 25, // x, y plus text arg
+    DrawTextScreen = 26, // x, y plus text arg
 
     MAX)
 


### PR DESCRIPTION
In non-blocking mode, BWEnv will block the game for a specified maximum amount
of time only before continuing. This enables abiding time limits for a given
match-up without adding complicated timing logic to the TorchCraft client
program.

If the client does not send commands for the current frame back in time (e.g.
receive in BWEnv times out), the game continues and a new attempt to receive
them will take place in the very next frame and so on until we finally get a
reply. If BWEnv absolutely has to send the frame (e.g. the game or battle is
over), it will perform a blocking receive call before sending it to abide the
REQ/REP pattern.

Please note the interplay with the SET_COMBINE_FRAMES option: BWEnv can only
send frame data to the client after having a received a message with commands.
Hence, if it is unable to send new frame data it will keep combining frames and
eventually send the combined frame in the next execution of
`Controller::onFrame()` after the successful receive. Hence, SET_COMBINE_FRAMES
defines a *minimum* number of combined frames for non-blocking mode.

The default behavior is blocking mode (i.e. the same as before). It can be
enabled specifically via the new SET_BLOCKING command. The timeout can also be
set via a new command; by default it's 50ms.