### PR TITLE
No more TH dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ ENDIF()
 SET_TARGET_PROPERTIES(torchcraft PROPERTIES
     VERSION   1.3.3
     SOVERSION 1.3.3)
-TARGET_LINK_LIBRARIES(torchcraft TH luaT zmq)
+TARGET_LINK_LIBRARIES(torchcraft luaT zmq)
 IF(ZSTD_FOUND)
     # Use the static library since we're using "advanced/experimental" features
     TARGET_LINK_LIBRARIES(torchcraft ${ZSTD_LIBDIR}/libzstd.a)

--- a/examples/py/dump_rep.py
+++ b/examples/py/dump_rep.py
@@ -6,6 +6,7 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import numpy as np
+import sys
 
 parser = argparse.ArgumentParser(
     formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -49,7 +50,7 @@ savePath = path.join(args.out, state.map_name + ".tcr")
 
 print("Saving to " + savePath)
 rep.setKeyFrame(-1)
-rep.save(savePath, False)
+rep.save(savePath, True)
 print('Done dumping replay')
 cl.send([[tcc.quit]])
 
@@ -75,6 +76,16 @@ if slset != trueslset:
     print(slset)
     print("While it should have: ")
     print(trueslset)
+
+for i in range(len(rep)):
+  f1 = rep.getFrame(i)
+  f2 = savedRep.getFrame(i)
+  good = f1.deepEq(f2)
+  if not good:
+    print("Saving failed! Frame {} doesn't match replay".format(i))
+    sys.exit(1)
+
+    
 
 def write_creep_map(framenum, outname):
     f = savedRep.getFrame(framenum)

--- a/examples/py/dump_rep.py
+++ b/examples/py/dump_rep.py
@@ -1,0 +1,89 @@
+import torchcraft as tc
+import torchcraft.Constants as tcc
+import argparse
+import os.path as path
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import numpy as np
+
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+)
+parser.add_argument('-t', '--hostname', default="localhost", type=str,
+                    help="Server to connect to")
+parser.add_argument('-p', '--port', default=11111, type=str,
+                    help="Port for torchcraft")
+parser.add_argument('-o', '--out', default="/tmp", 
+                    help="Where to save the replay")
+args = parser.parse_args()
+
+skip_frames = 3
+
+cl = tc.Client()
+cl.connect(args.hostname, args.port)
+state = cl.init()
+cl.send([
+    [tcc.set_speed, 0],
+    [tcc.set_gui, 0],
+    [tcc.set_combine_frames, skip_frames],
+    [tcc.set_frameskip, 1000],
+    [tcc.set_log, 0],
+    [tcc.set_cmd_optim, 1],
+])
+state = cl.recv()
+
+rep = tc.replayer.Replayer()
+rep.setMapFromState(state)
+fc = 0
+while not state.game_ended:
+    rep.push(state.frame)
+    fc += 1
+    if fc > 5000:
+        break
+    state = cl.recv()
+
+
+print("Game ended....")
+savePath = path.join(args.out, state.map_name + ".tcr")
+
+print("Saving to " + savePath)
+rep.setKeyFrame(-1)
+rep.save(savePath, False)
+print('Done dumping replay')
+cl.send([[tcc.quit]])
+
+savedRep = tc.replayer.load(savePath)
+savedMap = savedRep.getMap()
+def checkMap(ret, correct, desc, outname):
+    if (ret != np.asarray(correct).reshape(ret.shape)).sum() > 0:
+        print("{} map doesn't match, replayer is bugged!".format(desc))
+    plt.imshow(ret, cmap='hot', interpolation='nearest')
+    plt.savefig(outname)
+    plt.clf()
+checkMap(savedMap['walkability'], state.walkable_data, "Walkability", "/tmp/walkmap.png")
+checkMap(savedMap['ground_height'], state.ground_height_data, "Ground Height", "/tmp/heightmap.png")
+checkMap(savedMap['buildability'], state.buildable_data, "Buildability", "/tmp/buildmap.png")
+
+if len(savedMap['start_locations']) != len(state.start_locations):
+  print("Not the same number of start locations, replayer is bugged")
+
+slset = set(savedMap['start_locations'])
+trueslset = set((p.x, p.y) for p in state.start_locations)
+if slset != trueslset:
+    print("Start locations are bugged, replay has: ")
+    print(slset)
+    print("While it should have: ")
+    print(trueslset)
+
+def write_creep_map(framenum, outname):
+    f = savedRep.getFrame(framenum)
+    plt.imshow(f.creep_map(), cmap='hot', interpolation='nearest')
+    plt.savefig(outname)
+    plt.clf()
+write_creep_map(1, "/tmp/creep_map0.png")
+write_creep_map(999, "/tmp/creep_map1.png")
+write_creep_map(1999, "/tmp/creep_map2.png")
+write_creep_map(2999, "/tmp/creep_map3.png")
+write_creep_map(3999, "/tmp/creep_map4.png")
+write_creep_map(4999, "/tmp/creep_map5.png")

--- a/include/replayer.h
+++ b/include/replayer.h
@@ -89,27 +89,27 @@ class Replayer : public RefCounted {
     return numUnits.at(key);
   }
 
-  void setMapFromState(torchcraft::State* state);
+  void setMapFromState(torchcraft::State const* state);
 
   void setMap(
       int32_t h,
       int32_t w,
-      std::vector<uint8_t>& walkability,
-      std::vector<uint8_t>& ground_height,
-      std::vector<uint8_t>& buildability,
-      std::vector<int>& start_loc_x,
-      std::vector<int>& start_loc_y);
+      std::vector<uint8_t> const& walkability,
+      std::vector<uint8_t> const& ground_height,
+      std::vector<uint8_t> const& buildability,
+      std::vector<int> const& start_loc_x,
+      std::vector<int> const& start_loc_y);
 
   void setMap(
       int32_t h,
       int32_t w,
-      uint8_t* walkability,
-      uint8_t* ground_height,
-      uint8_t* buildability,
-      std::vector<int>& start_loc_x,
-      std::vector<int>& start_loc_y);
+      uint8_t const* const walkability,
+      uint8_t const* const ground_height,
+      uint8_t const* const buildability,
+      std::vector<int> const& start_loc_x,
+      std::vector<int> const& start_loc_y);
 
-  void setRawMap(uint32_t h, uint32_t w, uint8_t* d) {
+  void setRawMap(uint32_t h, uint32_t w, uint8_t const* d) {
     // free existing map if needed
     map.data.resize(h * w);
     map.data.assign(d, d + h * w);
@@ -126,7 +126,7 @@ class Replayer : public RefCounted {
       std::vector<uint8_t>& ground_height,
       std::vector<uint8_t>& buildability,
       std::vector<int>& start_loc_x,
-      std::vector<int>& start_loc_y);
+      std::vector<int>& start_loc_y) const;
 
   friend std::ostream& operator<<(std::ostream& out, const Replayer& o);
   friend std::istream& operator>>(std::istream& in, Replayer& o);

--- a/include/replayer.h
+++ b/include/replayer.h
@@ -113,6 +113,8 @@ class Replayer : public RefCounted {
     // free existing map if needed
     map.data.resize(h * w);
     map.data.assign(d, d + h * w);
+    map.height = h;
+    map.width = w;
   }
 
   const std::vector<uint8_t>& getRawMap() {

--- a/py/pyreplayer.cpp
+++ b/py/pyreplayer.cpp
@@ -234,29 +234,34 @@ void init_replayer(py::module& m) {
 // height is 0-5, hence 3 bits
 #define START_LOC_SHIFT 5
 
-            // TODO Figure out how to return a THTensor... Copying the code
-            // avoids an extra copy operation
             const auto map = self->getRawMap();
-            auto h = (uint64_t)THByteTensor_size(map, 0);
-            auto w = (uint64_t)THByteTensor_size(map, 1);
-            auto walkability = py::array_t<uint8_t>({h, w});
-            auto ground_height = py::array_t<uint8_t>({h, w});
-            auto buildability = py::array_t<uint8_t>({h, w});
+            auto h = self->mapHeight();
+            auto w = self->mapWidth();
+            auto w_vec = std::vector<uint8_t>();
+            auto g_vec = std::vector<uint8_t>();
+            auto b_vec = std::vector<uint8_t>();
+            auto sx = std::vector<int>();
+            auto sy = std::vector<int>();
+            self->getMap(w_vec, g_vec, b_vec, sx, sy);
+
+            auto walkability = py::array_t<uint8_t, py::array::c_style>({h, w});
+            auto ground_height = py::array_t<uint8_t, py::array::c_style>({h, w});
+            auto buildability = py::array_t<uint8_t, py::array::c_style>({h, w});
             auto w_data = walkability.mutable_unchecked<2>();
             auto g_data = ground_height.mutable_unchecked<2>();
             auto b_data = buildability.mutable_unchecked<2>();
 
+
             std::vector<std::pair<int, int>> start_loc;
             for (size_t y = 0; y < h; y++) {
               for (size_t x = 0; x < w; x++) {
-                uint8_t v = THTensor_fastGet2d(map, y, x);
-                w_data(y, x) = (v >> WALKABILITY_SHIFT) & 1;
-                b_data(y, x) = (v >> BUILDABILITY_SHIFT) & 1;
-                g_data(y, x) = (v >> HEIGHT_SHIFT) & 0b111;
-                bool is_start = ((v >> START_LOC_SHIFT) & 1) == 1;
-                if (is_start)
-                  start_loc.emplace_back(x, y);
+                w_data(y, x) = w_vec[y * w + x];
+                b_data(y, x) = b_vec[y * w + x];
+                g_data(y, x) = g_vec[y * w + x];
               }
+            }
+            for (auto i = 0U; i < sx.size(); i++) {
+              start_loc.emplace_back(sx[i], sy[i]);
             }
 
             py::dict ret;

--- a/py/pyreplayer.cpp
+++ b/py/pyreplayer.cpp
@@ -245,12 +245,13 @@ void init_replayer(py::module& m) {
             self->getMap(w_vec, g_vec, b_vec, sx, sy);
 
             auto walkability = py::array_t<uint8_t, py::array::c_style>({h, w});
-            auto ground_height = py::array_t<uint8_t, py::array::c_style>({h, w});
-            auto buildability = py::array_t<uint8_t, py::array::c_style>({h, w});
+            auto ground_height =
+                py::array_t<uint8_t, py::array::c_style>({h, w});
+            auto buildability =
+                py::array_t<uint8_t, py::array::c_style>({h, w});
             auto w_data = walkability.mutable_unchecked<2>();
             auto g_data = ground_height.mutable_unchecked<2>();
             auto b_data = buildability.mutable_unchecked<2>();
-
 
             std::vector<std::pair<int, int>> start_loc;
             for (size_t y = 0; y < h; y++) {

--- a/py/pyreplayer.cpp
+++ b/py/pyreplayer.cpp
@@ -174,6 +174,16 @@ void init_replayer(py::module& m) {
       .def_readwrite("reward", &Frame::reward)
       .def_readwrite("is_terminal", &Frame::is_terminal)
       .def("get_creep_at", &Frame::getCreepAt)
+      .def("creep_map", [](Frame* self) {
+          auto map = py::array_t<uint8_t, py::array::c_style>({self->height, self->width});
+          auto map_data = map.mutable_unchecked<2>();
+          for (auto y = 0U; y < self->height; y++) {
+            for (auto x = 0U; x < self->width; x++) {
+              map_data(y, x) = self->getCreepAt(x, y);
+            }
+          }
+          return map;
+          })
       .def("combine", &Frame::combine)
       .def("filter", &Frame::filter);
 

--- a/py/pyreplayer.cpp
+++ b/py/pyreplayer.cpp
@@ -173,6 +173,11 @@ void init_replayer(py::module& m) {
       .def_readwrite("width", &Frame::width)
       .def_readwrite("reward", &Frame::reward)
       .def_readwrite("is_terminal", &Frame::is_terminal)
+      .def("deepEq", [](Frame* self, Frame* other, bool debug) {
+          return torchcraft::replayer::detail::frameEq(self, other, debug);
+          },
+          py::arg("other"),
+          py::arg("debug") = false)
       .def("get_creep_at", &Frame::getCreepAt)
       .def("creep_map", [](Frame* self) {
           auto map = py::array_t<uint8_t, py::array::c_style>({self->height, self->width});

--- a/py/pyreplayer.cpp
+++ b/py/pyreplayer.cpp
@@ -173,21 +173,26 @@ void init_replayer(py::module& m) {
       .def_readwrite("width", &Frame::width)
       .def_readwrite("reward", &Frame::reward)
       .def_readwrite("is_terminal", &Frame::is_terminal)
-      .def("deepEq", [](Frame* self, Frame* other, bool debug) {
-          return torchcraft::replayer::detail::frameEq(self, other, debug);
+      .def(
+          "deepEq",
+          [](Frame* self, Frame* other, bool debug) {
+            return torchcraft::replayer::detail::frameEq(self, other, debug);
           },
           py::arg("other"),
           py::arg("debug") = false)
       .def("get_creep_at", &Frame::getCreepAt)
-      .def("creep_map", [](Frame* self) {
-          auto map = py::array_t<uint8_t, py::array::c_style>({self->height, self->width});
-          auto map_data = map.mutable_unchecked<2>();
-          for (auto y = 0U; y < self->height; y++) {
-            for (auto x = 0U; x < self->width; x++) {
-              map_data(y, x) = self->getCreepAt(x, y);
+      .def(
+          "creep_map",
+          [](Frame* self) {
+            auto map = py::array_t<uint8_t, py::array::c_style>(
+                {self->height, self->width});
+            auto map_data = map.mutable_unchecked<2>();
+            for (auto y = 0U; y < self->height; y++) {
+              for (auto x = 0U; x < self->width; x++) {
+                map_data(y, x) = self->getCreepAt(x, y);
+              }
             }
-          }
-          return map;
+            return map;
           })
       .def("combine", &Frame::combine)
       .def("filter", &Frame::filter);

--- a/replayer/frame.cpp
+++ b/replayer/frame.cpp
@@ -91,7 +91,8 @@ std::ostream& replayer::operator<<(
 }
 
 std::istream& replayer::operator>>(std::istream& in, replayer::Resources& r) {
-  in >> r.ore >> r.gas >> r.used_psi >> r.total_psi >> r.upgrades >> r.upgrades_level >> r.techs;
+  in >> r.ore >> r.gas >> r.used_psi >> r.total_psi >> r.upgrades >>
+      r.upgrades_level >> r.techs;
   return in;
 }
 
@@ -315,7 +316,7 @@ namespace detail = replayer::detail;
   F(airRange, 25)                     \
   F(playerId, 26)                     \
   F(resources, 27)                    \
-  F(buildTechUpgradeType, 28)                    \
+  F(buildTechUpgradeType, 28)         \
   F(remainingBuildTrainTime, 29)      \
   F(remainingUpgradeResearchTime, 30) \
   F(spellCD, 31)                      \

--- a/replayer/frame.cpp
+++ b/replayer/frame.cpp
@@ -441,16 +441,15 @@ void detail::add(Frame* f, Frame* frame, FrameDiff* df) {
   for (auto pair : df->creep_map)
     f->creep_map[pair.first] = pair.second;
 
-  auto frame_units = std::move(frame->units);
   f->units.clear();
 
   for (size_t i = 0; i < df->pids.size(); i++) {
     auto pid = df->pids[i];
     f->units[pid] = std::vector<replayer::Unit>();
 
-    auto f_units = frame_units.find(pid) == frame_units.end()
+    auto f_units = frame->units.find(pid) == frame->units.end()
         ? std::vector<replayer::Unit>()
-        : frame_units.at(pid);
+        : frame->units.at(pid);
     std::sort(f_units.begin(), f_units.end(), detail::orderUnitByiD);
 
     // Should be in order

--- a/replayer/replayer.cpp
+++ b/replayer/replayer.cpp
@@ -134,6 +134,8 @@ void Replayer::setMap(
     uint8_t* buildability,
     std::vector<int>& start_loc_x,
     std::vector<int>& start_loc_y) {
+  map.height = h;
+  map.width = w;
   map.data.resize(h * w);
   for (int y = 0; y < h; y++) {
     for (int x = 0; x < w; x++) {

--- a/replayer/replayer.cpp
+++ b/replayer/replayer.cpp
@@ -64,7 +64,7 @@ std::istream& operator>>(std::istream& in, Replayer& o) {
     o.keyframe = 0;
   }
   diffed = (diffed == 0); // Every kf is a Frame, others are frame diffs
-  if (height <= 0 || width <= 0 || height > 10000 || width > 10000 )
+  if (height <= 0 || width <= 0 || height > 10000 || width > 10000)
     throw std::runtime_error("Corrupted replay: invalid map size");
   uint8_t* data = (uint8_t*)malloc(sizeof(uint8_t) * height * width);
   in.ignore(1); // Ignores next space

--- a/replayer/replayer.cpp
+++ b/replayer/replayer.cpp
@@ -105,11 +105,11 @@ std::istream& operator>>(std::istream& in, Replayer& o) {
 void Replayer::setMap(
     int32_t h,
     int32_t w,
-    std::vector<uint8_t>& walkability,
-    std::vector<uint8_t>& ground_height,
-    std::vector<uint8_t>& buildability,
-    std::vector<int>& start_loc_x,
-    std::vector<int>& start_loc_y) {
+    std::vector<uint8_t> const& walkability,
+    std::vector<uint8_t> const& ground_height,
+    std::vector<uint8_t> const& buildability,
+    std::vector<int> const& start_loc_x,
+    std::vector<int> const& start_loc_y) {
   Replayer::setMap(
       h,
       w,
@@ -129,11 +129,11 @@ void Replayer::setMap(
 void Replayer::setMap(
     int32_t h,
     int32_t w,
-    uint8_t* walkability,
-    uint8_t* ground_height,
-    uint8_t* buildability,
-    std::vector<int>& start_loc_x,
-    std::vector<int>& start_loc_y) {
+    uint8_t const* const walkability,
+    uint8_t const* const ground_height,
+    uint8_t const* const buildability,
+    std::vector<int> const& start_loc_x,
+    std::vector<int> const& start_loc_y) {
   map.height = h;
   map.width = w;
   map.data.resize(h * w);
@@ -156,7 +156,7 @@ void Replayer::setMap(
   }
 }
 
-void Replayer::setMapFromState(torchcraft::State* state) {
+void Replayer::setMapFromState(torchcraft::State const* state) {
   auto w = state->map_size[0];
   auto h = state->map_size[1];
   std::vector<int> start_loc_x, start_loc_y;
@@ -179,7 +179,7 @@ std::pair<int32_t, int32_t> Replayer::getMap(
     std::vector<uint8_t>& ground_height,
     std::vector<uint8_t>& buildability,
     std::vector<int>& start_loc_x,
-    std::vector<int>& start_loc_y) {
+    std::vector<int>& start_loc_y) const {
   auto h = mapHeight();
   auto w = mapWidth();
   walkability.resize(h * w);

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ ext_modules = [
         # TODO Search for ZSTD and define this if it exists
         define_macros=[('WITH_ZSTD', None)],
         library_dirs=[torch_libdir],
-        libraries=['TH', 'zstd', 'zmq'],
+        libraries=['zstd', 'zmq'],
         language='c++'
     ),
 ]


### PR DESCRIPTION
- No more torch7 dependencies on the C++ / Python side! Instead uses numpy arrays, and lua uses torch7 tensors. 
- Added a replay test for the python side
- Fixed a bug with dumping replays since.... 4 months ago? wtf?

Buildmap:
![buildmap](https://user-images.githubusercontent.com/3605224/32257153-d118b87c-be89-11e7-9f41-ca3f558aeeff.png)

Walkmap:
![walkmap](https://user-images.githubusercontent.com/3605224/32257157-d647bd70-be89-11e7-8a49-0f3e41fe53bb.png)

Ground height map:
![heightmap](https://user-images.githubusercontent.com/3605224/32257166-de779fb0-be89-11e7-814d-b2621d6fc78c.png)

Creep maps (chronologically from frames 1, 1k, 2k, 3k, and 4k from the TL replay in the repo):
![creep_map0](https://user-images.githubusercontent.com/3605224/32257178-efe7cf04-be89-11e7-97f4-df388249084b.png)
![creep_map1](https://user-images.githubusercontent.com/3605224/32257179-effc21c0-be89-11e7-9970-ff33103a9f94.png)
![creep_map2](https://user-images.githubusercontent.com/3605224/32257180-f00e4c9c-be89-11e7-9121-5a1d7ff74c68.png)
![creep_map3](https://user-images.githubusercontent.com/3605224/32257181-f023132a-be89-11e7-9d9b-368b81760ae8.png)
![creep_map4](https://user-images.githubusercontent.com/3605224/32257182-f02ffcd4-be89-11e7-89b8-13a3ea4cd9e4.png)
![creep_map5](https://user-images.githubusercontent.com/3605224/32257183-f0482e4e-be89-11e7-8b7f-918919c5b631.png)


Lua also builds as expected.

