### PR TITLE
Fixed Lua wrapper warnings about signed/unsigned comparisons

### DIFF
--- a/lua/gamestore.h
+++ b/lua/gamestore.h
@@ -44,14 +44,14 @@ class CircularBuffer {
   explicit CircularBuffer(size_t size)
       : size(size), head(0), tail(0), length(0) {
     buffer.resize(size);
-    for (int i = 0; i < size; i++) {
+    for (uint i = 0; i < size; i++) {
       buffer[i] = nullptr;
     }
   }
 
   ~CircularBuffer() {
     // free the replayers
-    for (int i = 0; i < size; i++) {
+    for (uint i = 0; i < size; i++) {
       if (buffer[i] != nullptr) {
         buffer[i]->decref();
         buffer[i] = nullptr;
@@ -84,7 +84,7 @@ class CircularBuffer {
 
   // clears the buffer
   void clear() {
-    for (int i = 0; i < size; i++) {
+    for (uint i = 0; i < size; i++) {
       if (buffer[i] != nullptr) {
         delete buffer[i];
         buffer[i] = nullptr;

--- a/lua/replayer_lua.cpp
+++ b/lua/replayer_lua.cpp
@@ -214,7 +214,7 @@ extern "C" int replayerGetMap(lua_State* L) {
   luaT_pushudata(L, heightmap, "torch.ByteTensor");
   luaT_pushudata(L, buildmap, "torch.ByteTensor");
   lua_createtable(L, start_loc_x.size(), 0);
-  for (int i = 0; i < start_loc_x.size(); i++) {
+  for (uint i = 0; i < start_loc_x.size(); i++) {
     lua_createtable(L, 2, 0);
     lua_pushinteger(L, start_loc_x[i]);
     lua_setfield(L, -2, "x");

--- a/lua/state_lua.cpp
+++ b/lua/state_lua.cpp
@@ -256,7 +256,7 @@ void updateUserValueAndPush(
 
   // Still up to date?
   lua_getfield(L, -1, "__numUpdates");
-  if (lua_tonumber(L, -1) == (long) s->numUpdates) {
+  if ((long) lua_tonumber(L, -1) == (long) s->numUpdates) {
     lua_pop(L, 1);
     lua_getfield(L, -1, m.c_str());
     lua_remove(L, -2);

--- a/lua/state_lua.cpp
+++ b/lua/state_lua.cpp
@@ -256,7 +256,7 @@ void updateUserValueAndPush(
 
   // Still up to date?
   lua_getfield(L, -1, "__numUpdates");
-  if ((long) lua_tointeger(L, -1) == (long) s->numUpdates) {
+  if (lua_tonumber(L, -1) == (long) s->numUpdates) {
     lua_pop(L, 1);
     lua_getfield(L, -1, m.c_str());
     lua_remove(L, -2);

--- a/lua/state_lua.cpp
+++ b/lua/state_lua.cpp
@@ -256,7 +256,7 @@ void updateUserValueAndPush(
 
   // Still up to date?
   lua_getfield(L, -1, "__numUpdates");
-  if (lua_tointeger(L, -1) == s->numUpdates) {
+  if ((long) lua_tointeger(L, -1) == (long) s->numUpdates) {
     lua_pop(L, 1);
     lua_getfield(L, -1, m.c_str());
     lua_remove(L, -2);
@@ -277,7 +277,7 @@ void updateUserValueAndPush(
     auto nplayers = s->units.size();
     lua_newtable(L);
     for (size_t p = 0; p < nplayers; p++) {
-      if (p != s->neutral_id) {
+      if ((long) p != (long) s->neutral_id) {
         pushUnits(L, s->units[p]);
         lua_rawseti(L, -2, p);
       }
@@ -286,7 +286,7 @@ void updateUserValueAndPush(
 
     lua_newtable(L);
     for (size_t p = 0; p < nplayers; p++) {
-      if (p != s->neutral_id) {
+      if ((long) p != (long) s->neutral_id) {
         pushFrameMember(L, s, frameGetResources, p);
         lua_rawseti(L, -2, p);
       }


### PR DESCRIPTION
https://github.com/TorchCraft/TorchCraft/issues/218

Compiling TorchCraft produced a bunch of warnings about signed/unsigned integer comparison. Now it doesn't.

@jgehring @ebetica @syhw 