### PR TITLE
MSVC error/warning fixes + better Visual Studio default settings

### DIFF
--- a/BWEnv/VisualStudio/BWEnv.sln
+++ b/BWEnv/VisualStudio/BWEnv.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.40629.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27004.2006
 MinimumVisualStudioVersion = 12.0.0
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "BWEnv", "BWEnv.vcxproj", "{AE3B9DC4-5FBB-4B57-8AB4-0D84D8649D78}"
 EndProject
@@ -12,8 +12,8 @@ Global
 		Release|Win32 = Release|Win32
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{AE3B9DC4-5FBB-4B57-8AB4-0D84D8649D78}.Debug|Win32.ActiveCfg = Debug|Win32
-		{AE3B9DC4-5FBB-4B57-8AB4-0D84D8649D78}.Debug|Win32.Build.0 = Debug|Win32
+		{AE3B9DC4-5FBB-4B57-8AB4-0D84D8649D78}.Debug|Win32.ActiveCfg = Release|Win32
+		{AE3B9DC4-5FBB-4B57-8AB4-0D84D8649D78}.Debug|Win32.Build.0 = Release|Win32
 		{AE3B9DC4-5FBB-4B57-8AB4-0D84D8649D78}.DLL-Debug|Win32.ActiveCfg = DLL-Debug|Win32
 		{AE3B9DC4-5FBB-4B57-8AB4-0D84D8649D78}.DLL-Debug|Win32.Build.0 = DLL-Debug|Win32
 		{AE3B9DC4-5FBB-4B57-8AB4-0D84D8649D78}.DLL-Release|Win32.ActiveCfg = DLL-Release|Win32
@@ -23,5 +23,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BFC2F1B0-38A3-4C7A-8020-2F68838AE062}
 	EndGlobalSection
 EndGlobal

--- a/BWEnv/VisualStudio/BWEnv.vcxproj
+++ b/BWEnv/VisualStudio/BWEnv.vcxproj
@@ -23,7 +23,7 @@
     <RootNamespace>BWEnv</RootNamespace>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>BWEnv</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/BWEnv/src/controller.cc
+++ b/BWEnv/src/controller.cc
@@ -961,8 +961,8 @@ void Controller::packCreep(replayer::Frame& f) {
   auto height = f.height / 4;
   auto width = f.width / 4;
   f.creep_map.resize(height * width / 8); // Only store build tiles
-  for (int y = 0, i = 0; y < height; ++y) {
-    for (int x = 0; x < width; ++x, ++i) {
+  for (unsigned y = 0, i = 0; y < height; ++y) {
+    for (unsigned x = 0; x < width; ++x, ++i) {
       f.creep_map[i / 8] |= BWAPI::Broodwar->hasCreep(x, y) << (i % 8);
     }
   }

--- a/include/flatbuffer_conversions.h
+++ b/include/flatbuffer_conversions.h
@@ -19,7 +19,7 @@ namespace replayer {
 
 // Serialize to FlatBuffers
 
-auto packActionsOfPlayer = [](flatbuffers::FlatBufferBuilder& builder) {
+const auto packActionsOfPlayer = [](flatbuffers::FlatBufferBuilder& builder) {
   return [&builder](const std::pair<int32_t, std::vector<Action>>& actionPair) {
     auto packAction = [&builder](const Action& action) {
       auto actionsOffset = builder.CreateVector(action.action);
@@ -49,7 +49,7 @@ auto packActionsOfPlayer = [](flatbuffers::FlatBufferBuilder& builder) {
   };
 };
 
-auto packResourcesOfPlayer = [](flatbuffers::FlatBufferBuilder& builder) {
+const auto packResourcesOfPlayer = [](flatbuffers::FlatBufferBuilder& builder) {
   return [&builder](const std::pair<int32_t, Resources>& resourcesPair) {
     auto resources = resourcesPair.second;
     fbs::ResourcesBuilder fbsResourcesBuilder(builder);
@@ -72,13 +72,13 @@ auto packResourcesOfPlayer = [](flatbuffers::FlatBufferBuilder& builder) {
   };
 };
 
-auto packBullet = [](const Bullet& bullet) {
+const auto packBullet = [](const Bullet& bullet) {
   return fbs::Bullet(bullet.type, bullet.x, bullet.y);
 };
 
 // Deserialize from FlatBuffers
 
-auto unpackAction = [](const fbs::Action* fbsAction) {
+const auto unpackAction = [](const fbs::Action* fbsAction) {
   assert(fbsAction);
   assert(fbsAction->action());
   auto fbsActionInts = fbsAction->action();
@@ -90,7 +90,7 @@ auto unpackAction = [](const fbs::Action* fbsAction) {
   return action;
 };
 
-auto unpackResources = [](const fbs::ResourcesOfPlayer* fbsResourcesOfPlayer) {
+const auto unpackResources = [](const fbs::ResourcesOfPlayer* fbsResourcesOfPlayer) {
   auto fbsResources = fbsResourcesOfPlayer->resources();
   auto resources = std::make_pair(fbsResourcesOfPlayer->playerId(), Resources()) ;
   resources.second.ore = fbsResources->ore();
@@ -103,7 +103,7 @@ auto unpackResources = [](const fbs::ResourcesOfPlayer* fbsResourcesOfPlayer) {
   return resources;
 };
 
-auto unpackBullet = [](const fbs::Bullet* fbsBullet) {
+const auto unpackBullet = [](const fbs::Bullet* fbsBullet) {
   Bullet bullet;
   bullet.type = fbsBullet->type();
   bullet.x = fbsBullet->x();


### PR DESCRIPTION
* Fixed MSVC error: Namespace-scope lambdas in header files need to be const or the linker suffers duplicate name confusion
* Fixed MSVC warning: unsigned integer comparison
* Set required Windows SDK version to be less specific
* Set default Visual Studio configuration to Release
