### PR TITLE
Fix assignment operator for Frame

### DIFF
--- a/include/frame.h
+++ b/include/frame.h
@@ -319,7 +319,7 @@ class Frame : public RefCounted {
   Frame(Frame&& o);
   Frame(const Frame& o);
   Frame(const Frame* o);
-  Frame& operator=(Frame& other);
+  Frame& operator=(Frame other);
 
   void swap(Frame& a, Frame& b);
   void clear();

--- a/include/frame.h
+++ b/include/frame.h
@@ -319,7 +319,7 @@ class Frame : public RefCounted {
   Frame(Frame&& o);
   Frame(const Frame& o);
   Frame(const Frame* o);
-  Frame& operator=(Frame other);
+  Frame& operator=(Frame other) noexcept;
 
   void swap(Frame& a, Frame& b);
   void clear();

--- a/replayer/frame.cpp
+++ b/replayer/frame.cpp
@@ -63,7 +63,7 @@ void Frame::swap(Frame& a, Frame& b) {
   swap(a.is_terminal, b.is_terminal);
 }
 
-Frame& Frame::operator=(Frame& other) {
+Frame& Frame::operator=(Frame other) {
   swap(*this, other);
   return *this;
 }

--- a/replayer/frame.cpp
+++ b/replayer/frame.cpp
@@ -63,7 +63,7 @@ void Frame::swap(Frame& a, Frame& b) {
   swap(a.is_terminal, b.is_terminal);
 }
 
-Frame& Frame::operator=(Frame other) {
+Frame& Frame::operator=(Frame other) noexcept {
   swap(*this, other);
   return *this;
 }


### PR DESCRIPTION
The existing assignment operator prohibits assignment from rvalues. Its implementation is a typical copy-and-swap operation, it is compatible with copy and move logic. So changing the unorthodox pass-by-reference (as compared to pass-by-const-reference) to pass-by-value.