### PR TITLE
Add ability to set maximum number of combined frames

### DIFF
--- a/BWEnv/include/controller.h
+++ b/BWEnv/include/controller.h
@@ -43,7 +43,7 @@ enum Commands {
   SET_GUI,
   SET_FRAMESKIP,
   SET_CMD_OPTIM,
-  SET_COMBINE_FRAMES,
+  SET_COMBINE_FRAMES, // one or two args actually
   SET_MAP,
   SET_MULTI,
   SET_BLOCKING,
@@ -156,6 +156,7 @@ class Controller {
   static const int pixelsPerWalkTile = 8;
   bool logCommands = true;
   int min_combine_frames = 1;
+  int max_combine_frames = -1;
   int combined_frames = 0;
   bool last_receive_ok = true;
   replayer::Frame* last_frame = nullptr;

--- a/examples/lua/dump_replay.lua
+++ b/examples/lua/dump_replay.lua
@@ -35,7 +35,9 @@ local map = tc:connect(params.hostname, params.port)
 assert(tc.state.replay, "This game isn't a replay")
 tc:send({table.concat({
   tc.command(tc.set_speed, 0), tc.command(tc.set_gui, 0),
-  tc.command(tc.set_combine_frames, skip_frames),
+  tc.command(tc.set_combine_frames, skip_frames, skip_frames),
+  tc.command(tc.set_blocking, 0),
+  tc.command(tc.set_max_frame_time_ms, 0),
   tc.command(tc.set_frameskip, 1000), tc.command(tc.set_log, 0),
 }, ':')})
 tc:receive()

--- a/examples/py/dump_rep.py
+++ b/examples/py/dump_rep.py
@@ -27,7 +27,9 @@ state = cl.init()
 cl.send([
     [tcc.set_speed, 0],
     [tcc.set_gui, 0],
-    [tcc.set_combine_frames, skip_frames],
+    [tcc.set_combine_frames, skip_frames, skip_frames],
+    [tcc.set_max_frame_time_ms, 0],
+    [tcc.set_blocking, 0],
     [tcc.set_frameskip, 1000],
     [tcc.set_log, 0],
     [tcc.set_cmd_optim, 1],
@@ -43,7 +45,6 @@ while not state.game_ended:
     if fc > 5000:
         break
     state = cl.recv()
-
 
 print("Game ended....")
 savePath = path.join(args.out, state.map_name + ".tcr")

--- a/include/constants.h
+++ b/include/constants.h
@@ -48,7 +48,12 @@ BETTER_ENUM(
     SetGui = 8, // activates drawing and text in SC (bool)
     SetFrameskip = 9, // number of frames to skip (int)
     SetCmdOptim = 10, // reduce bot APM (0-6)
-    SetCombineFrames = 11, // combine n frames before sending (int)
+    // Combine min[/max] frames before sending (int [,int])
+    // In blocking mode, always combine according to minimum of arguments passed
+    // In non-blocking mode, it's possible to set a lower and upper limit.
+    // Reaching the upper limit results in blocking. Setting a single number
+    // disables the upper limit.
+    SetCombineFrames = 11,
 
     // Sets the map with BWAPI->setMap and by writing to the config. Is not
     // thread-safe. However, as long as the next connect finishes after set_map,


### PR DESCRIPTION
The `COMBINE_FRAMES` option takes either one or two arguments now. With two
argument, it allows setting a maximum number of combined frames. This is useful
in non-blocking mode, in which `COMBINE_FRAMES` previously acted as a *minimum*
number of combined frames. If a maximum is set, BWEnv will block and wait for a
client requests once the maximum number of combined frames has been reached.

The intended use-case is to speed up processing of replays. It's usually
desirable to have a constant number of combined frames per server reply (i.e.
setting `COMBINE_FRAMES` and enabling `BLOCKING`). However, waiting for a client
request does, in many cases, not make much sense because the client might not
issue any commands. With setting a minmum and maximum combination value  and
disabling `BLOCKING` (and setting a very low maximum frame duration), the server
will only block once a given number of new frames are ready and otherwise just
briefly check for new client requests.

I did a small benchmark with the `examples/py/dump_rep.py` and measured the
(wall clock) time on macOS that it takes to receive 5000 frames from
"maps/replays/bwrep_gwhxe.rep": 20.7s for the previous version, and 16.9s when
setting the options mentioned above (they are added to the dump_replay scripts in
the following commit). The difference should be more pronounced if client
programs are doing some actual working during replay processing.