### PR TITLE
Fix units not disappearing

### DIFF
--- a/client/state.cpp
+++ b/client/state.cpp
@@ -431,6 +431,12 @@ void State::postUpdate(std::vector<std::string>& upd) {
   }
 
   // Update units
+  for (auto& us : units) {
+    if (frame->units.find(us.first) == frame->units.end()) {
+      // No more units from this team
+      us.second.clear();
+    }
+  }
   for (const auto& fus : frame->units) {
     auto player = fus.first;
     if (units.find(player) == units.end()) {


### PR DESCRIPTION
state->units() didn't update correctly when there are no more units in the game from that player. This results in some strange bugs in micro scenarios when units of a team die but show up in state->units.