### PR TITLE
Filter units for all controllable players

### DIFF
--- a/client/state.cpp
+++ b/client/state.cpp
@@ -452,8 +452,8 @@ void State::postUpdate(std::vector<std::string>& upd) {
         [this, player](const Unit& unit) {
           auto ut = torchcraft::BW::UnitType::_from_integral_nothrow(unit.type);
           return (
-              // Unit is of known type (or enemy unit)
-              (player != player_id || ut) &&
+              // Unit is of known type (or a neutral unit)
+              (player == neutral_id || ut) &&
               // Unit has not been marked dead
               std::find(deaths.begin(), deaths.end(), unit.id) == deaths.end());
         });


### PR DESCRIPTION
The change is minimal, but it is quite significant.

Previously, only the controlled player would have their units filtered in `state.units`, while now the only units list that *won't* be filtered will be the neutral player's.

This allows us to maintain some consistency in the state, while also enabling us to consider some of the pro maps that use special neutral blocks to block paths without having to refer to `state.frame.units`.