### PR TITLE
Enable sharing of ZMQ context between active connections

### DIFF
--- a/client/connection.cpp
+++ b/client/connection.cpp
@@ -162,6 +162,8 @@ zmq::context_t& Connection::refContext() {
     auto numIoThreads =
         std::max(1, std::min(2, int(std::thread::hardware_concurrency()) - 1));
     context_ = new zmq::context_t(numIoThreads);
+  } else if (context_ == nullptr) {
+    throw std::runtime_error("ZMQ context not initialized");
   }
   return *context_;
 }
@@ -172,6 +174,9 @@ void Connection::derefContext() {
   if (contextRef_ == 0) {
     delete context_;
     context_ = nullptr;
+  }
+  if (contextRef_ < 0) {
+    throw std::runtime_error("ZMQ context ref counter < 0");
   }
 }
 

--- a/client/connection.cpp
+++ b/client/connection.cpp
@@ -15,7 +15,10 @@
 
 namespace torchcraft {
 
-static const std::string ERRMSG_TIMEOUT_EXCEEDED = "Timeout exceeded";
+namespace {
+const std::string ERRMSG_TIMEOUT_EXCEEDED = "Timeout exceeded";
+}
+
 zmq::context_t* Connection::context_ = nullptr;
 int Connection::contextRef_ = 0;
 std::mutex Connection::contextMutex_;

--- a/client/connection.cpp
+++ b/client/connection.cpp
@@ -14,13 +14,7 @@
 
 namespace torchcraft {
 
-///////////////////////// LOCAL DECLARATIONS /////////////////////////////////
-
 static const std::string ERRMSG_TIMEOUT_EXCEEDED = "Timeout exceeded";
-
-/////////////////////////////// PUBLIC ///////////////////////////////////////
-
-//============================= LIFECYCLE ====================================
 
 Connection::Connection(
     const std::string& hostname,
@@ -50,7 +44,6 @@ Connection::Connection(
 Connection::Connection(Connection&& conn)
     : ctx_(std::move(conn.ctx_)), sock_(std::move(conn.sock_)) {}
 
-//============================= OPERATIONS ===================================
 
 bool Connection::send(const std::string& data) {
   clearError();

--- a/client/connection.cpp
+++ b/client/connection.cpp
@@ -9,41 +9,45 @@
 
 #include <iostream>
 #include <sstream>
+#include <thread>
 
 #include "connection.h"
 
 namespace torchcraft {
 
 static const std::string ERRMSG_TIMEOUT_EXCEEDED = "Timeout exceeded";
+zmq::context_t* Connection::context_ = nullptr;
+int Connection::contextRef_ = 0;
+std::mutex Connection::contextMutex_;
 
-Connection::Connection(
-    const std::string& hostname,
-    int port,
-    int timeoutMs)
-    : sock_(ctx_, zmq::socket_type::req) {
+Connection::Connection(const std::string& hostname, int port, int timeoutMs)
+    : ctx_(refContext()), sock_(ctx_, zmq::socket_type::req) {
   std::ostringstream ss;
   ss << "tcp://" << hostname << ":" << port;
   sock_.setsockopt(ZMQ_SNDTIMEO, &timeoutMs, sizeof(timeoutMs));
   sock_.setsockopt(ZMQ_RCVTIMEO, &timeoutMs, sizeof(timeoutMs));
+  sock_.setsockopt(ZMQ_LINGER, 10);
   sock_.setsockopt(ZMQ_IPV6, 1);
   sock_.connect(ss.str());
 } // Connection
 
-Connection::Connection(
-    const std::string& file_socket,
-    int timeoutMs)
-    : sock_(ctx_, zmq::socket_type::req) {
+Connection::Connection(const std::string& file_socket, int timeoutMs)
+    : ctx_(refContext()), sock_(ctx_, zmq::socket_type::req) {
   std::ostringstream ss;
   ss << "ipc://" << file_socket;
   sock_.setsockopt(ZMQ_SNDTIMEO, &timeoutMs, sizeof(timeoutMs));
   sock_.setsockopt(ZMQ_RCVTIMEO, &timeoutMs, sizeof(timeoutMs));
+  sock_.setsockopt(ZMQ_LINGER, 10);
   sock_.setsockopt(ZMQ_IPV6, 1);
   sock_.connect(ss.str());
 } // Connection
 
 Connection::Connection(Connection&& conn)
-    : ctx_(std::move(conn.ctx_)), sock_(std::move(conn.sock_)) {}
+    : ctx_(refContext()), sock_(std::move(conn.sock_)) {}
 
+Connection::~Connection() {
+  derefContext();
+}
 
 bool Connection::send(const std::string& data) {
   clearError();
@@ -133,6 +137,39 @@ bool Connection::poll(long timeout) {
 void Connection::clearError() {
   errnum_ = 0;
   errmsg_.clear();
+}
+
+zmq::context_t& Connection::refContext() {
+  std::lock_guard<std::mutex> guard(contextMutex_);
+  contextRef_++;
+  if (contextRef_ == 1) {
+    if (context_ != nullptr) {
+      throw std::runtime_error("ZMQ context already initialized");
+    }
+    // Quote from http://zeromq.org/area:faq#toc7
+    // "The basic heuristic is to allocate 1 I/O thread in the context for every
+    // gigabit per second of data that will be sent and received (aggregated).
+    // Further, the number of I/O threads should not exceed (number_of_cpu_cores
+    // - 1)."
+    // We might hit 1 Gbit/s if we run a lot of non-trivial self-play games on a
+    // machine
+    // with many cores (say, 80 logical ones). So we'll ideally go for 2
+    // threads,
+    // subject to the number of cores, but fall back to 1 for small systems.
+    auto numIoThreads =
+        std::max(1, std::min(2, int(std::thread::hardware_concurrency()) - 1));
+    context_ = new zmq::context_t(numIoThreads);
+  }
+  return *context_;
+}
+
+void Connection::derefContext() {
+  std::lock_guard<std::mutex> guard(contextMutex_);
+  contextRef_--;
+  if (contextRef_ == 0) {
+    delete context_;
+    context_ = nullptr;
+  }
 }
 
 } // namespace torchcraft

--- a/client/connection.h
+++ b/client/connection.h
@@ -9,10 +9,25 @@
 
 #pragma once
 
+#include <mutex>
+
 #include "zmq.hpp"
 
 namespace torchcraft {
 
+/**
+ * Simple convenience wrapper for a ZeroMQ connection.
+ *
+ * See member function documentation for usage details.
+ *
+ * Implementation details: With the exception of constructors and destructors,
+ * functions do not throw on I/O failures but return `false` and provide error
+ * information via `errnum()` and `errmsg()`.
+ * Concurrent connections will share the same ZeroMQ context. The context will
+ * be destroyed once the last active connection is destructed. This provides
+ * context sharing when required for efficiency (processes with many open
+ * connections) and makes sure that contexts are properly cleaned up.
+ */
 class Connection {
  public:
   /// Creates a new socket and connects it to an endpoint specified
@@ -46,6 +61,7 @@ class Connection {
 
   Connection(const Connection&) = delete;
   Connection& operator=(const Connection&) = delete;
+  ~Connection();
 
   /// Send data in a string format over the socket connection
   /// @param data [in] Data to send to the socket
@@ -80,11 +96,17 @@ class Connection {
  private:
   void clearError();
 
-  zmq::context_t ctx_;
+  zmq::context_t& ctx_;
   zmq::socket_t sock_;
   zmq::message_t recvmsg_;
   int errnum_ = 0;
   std::string errmsg_;
+
+  static zmq::context_t& refContext();
+  static void derefContext();
+  static zmq::context_t* context_;
+  static int contextRef_;
+  static std::mutex contextMutex_;
 };
 
 } // namespace torchcraft

--- a/client/connection.h
+++ b/client/connection.h
@@ -97,7 +97,7 @@ class Connection {
   void clearError();
 
   zmq::context_t& ctx_;
-  zmq::socket_t sock_;
+  std::unique_ptr<zmq::socket_t> sock_;
   zmq::message_t recvmsg_;
   int errnum_ = 0;
   std::string errmsg_;

--- a/client/connection.h
+++ b/client/connection.h
@@ -15,8 +15,6 @@ namespace torchcraft {
 
 class Connection {
  public:
-  // LIFECYCLE
-
   /// Creates a new socket and connects it to an endpoint specified
   /// by a hostname and a port. TCP transport protocol is used
   /// for the connection; the full address is thus
@@ -48,8 +46,6 @@ class Connection {
 
   Connection(const Connection&) = delete;
   Connection& operator=(const Connection&) = delete;
-
-  // OPERATIONS
 
   /// Send data in a string format over the socket connection
   /// @param data [in] Data to send to the socket


### PR DESCRIPTION
For training runs, we can easily have >80 active TorchCraft connections per
process (e.g. >40 self-play games running in parallel). Constantly constructing
and destructing a ZeroMQ context for each connection is both a waste of time and
resources, since each context will result in a dedicated I/O thread. This change
enables context sharing across across *active* connections -- once the last
connection is closed, the shared context is destroyed and re-created on the
next connection attempt.

I did some basic benchmarking, and for a relatively simple self-play game I saw
500 MBit going over the wire in total (send/receive for both players) within 30
seconds. Assuming twice the size for a more complex game, we'd hit 1 Gbps with
30 parallel games. The ZeroMQ FAQ (http://zeromq.org/area:faq#toc7) suggest to
use one thread for every Gpbs so I went with two threads to be safe. In reality,
we're often performing other operations while playing, which slows down the game
and reduces the required throughput. If the game gets more complex, player steps
will be slower as well.

ZeroMQ contexts are not designed to be created and destroyed frequently anyway;
they should be retained for a longer time. On the other hand, for a library, I
still believe that it's good design to not allocate a lot of global resources
which are supposed to be cleaned up at program exit. Hence, the solution here
seems like a good compromise.

This also includes setting the "linger" period for connection sockets. This is
infinite by default, but now that the context can outlive the connection we
don't want pending messages to linger in the context for too long.