### PR TITLE
Add OpenBW docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ TorchCraft is split into two parts: **BWEnv**, the process that runs along with 
 - To install BWEnv and StarCraft on WINE, please check these [instructions](/docs/starcraft_in_wine.md).
 - To install BWEnv using OpenBW, please check follow these [instructions](/docs/openbw.md).
 
+Dockerfiles are also available in `docker` directory; please see the relevant [README](docker/README.md).
 
 Each client has a different installation procedure, but all have the same library requirements (see above).
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,7 +5,8 @@
 You can build the image by running:
 ```bash
 $ cd docker
-$ docker build -f openbw/Dockerfile -t torchcraft-obw --build-arg TC_BRANCH=master OBW_GUI=1
+$ docker build -f openbw/Dockerfile -t torchcraft-obw \
+  --build-arg TC_BRANCH=master --build-arg OBW_GUI=1 .
 ```
 
 Then you can simply run BWAPILauncher by doing:
@@ -36,18 +37,18 @@ to `TorchCraft/docker/common/Downloader_StarCraft_Combo_enUS.exe`
 
 From the current directory:
 
-`docker build -f no-cuda/Dockerfile -t torchcraft .`
+`docker build -f no-cuda/Dockerfile -t torchcraft-std .`
 
 or if you want CUDA, install the [nvidia docker](https://github.com/NVIDIA/nvidia-docker) plugin first and:
 
-`docker build -f cuda/Dockerfile -t cutorchcraft .`
+`docker build -f cuda/Dockerfile -t torchcraft-std-cu .`
 
 To run the client:
 
 ```
-docker run --rm --privileged -it -p 5900:5900 torchcraft bash
+docker run --rm --privileged -it -p 5900:5900 torchcraft-std bash
 # For a docker image with CUDA support:
-nvidia-docker run --rm --privileged -it -p 5900:5900 cutorchcraft bash
+nvidia-docker run --rm --privileged -it -p 5900:5900 torchcraft-std bash
 # Setup wine
 wine wineboot --init
 winetricks -q vcrun2013
@@ -86,12 +87,12 @@ docker ps -a
 docker commit $ID
 # Note the ID of the image you just created
 # Optionally, tag it with something else
-docker tag $IMAGE_ID torchcraft:my_version
-docker save $IMAGE_ID -o torchcraft.docker
+docker tag $IMAGE_ID torchcraft-std:my_version
+docker save $IMAGE_ID -o torchcraft-std.docker
 ```
 
 ### Importing
 ```
-docker load -i torchcraft.docker
-docker run --rm --privileged -it -p 5900:5900 torchcraft:my_version bash
+docker load -i torchcraft-std.docker
+docker run --rm --privileged -it -p 5900:5900 torchcraft-std:my_version bash
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,5 +1,35 @@
 # Torchcraft on Docker
-## Install the image
+
+## OpenBW image
+
+You can build the image by running:
+```bash
+$ cd docker
+$  docker build -f openbw/Dockerfile -t torchcraft-obw --build-arg TC_BRANCH=master OBW_GUI=1
+```
+
+Then you can simply run BWAPILauncher by doing:
+
+```bash
+$ docker run -it -p 11111:11111 -v /your/path/to/mpqs:/mpqs torchcraft-obw
+root@image$ cd /mpqs
+root@image$ OPENBW_ENABLE_UI=0 \
+   BWAPI_CONFIG_AI__RACE=Terran \
+   BWAPI_CONFIG_AI__AI=/torchcraft/BWEnv/build/BWEnv.so \
+   BWAPI_CONFIG_AUTO_MENU__AUTO_MENU="SINGLE_PLAYER" \
+   BWAPI_CONFIG_AUTO_MENU__MAP=/torchcraft/maps/micro/m5v5_c_far.scm \
+   BWAPI_CONFIG_AUTO_MENU__GAME_TYPE="USE MAP SETTINGS" \
+   TORCHCRAFT_PORT=11111 \
+   BWAPILauncher
+```
+
+* `TC_BRANCH` allows you to control which version of torchcraft to clone (defaults to `master`)
+* `OBW_GUI` allows you to control whether to compile OpenBW with sdl support (defaults to `1`)
+
+
+## Standard Image
+
+### Building the image
 
 First, download the [Starcraft: Brood War installer](https://us.battle.net/account/management/)
 to `TorchCraft/docker/common/Downloader_StarCraft_Combo_enUS.exe`

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,7 +5,7 @@
 You can build the image by running:
 ```bash
 $ cd docker
-$  docker build -f openbw/Dockerfile -t torchcraft-obw --build-arg TC_BRANCH=master OBW_GUI=1
+$ docker build -f openbw/Dockerfile -t torchcraft-obw --build-arg TC_BRANCH=master OBW_GUI=1
 ```
 
 Then you can simply run BWAPILauncher by doing:
@@ -18,7 +18,7 @@ root@image$ OPENBW_ENABLE_UI=0 \
    BWAPI_CONFIG_AI__AI=/torchcraft/BWEnv/build/BWEnv.so \
    BWAPI_CONFIG_AUTO_MENU__AUTO_MENU="SINGLE_PLAYER" \
    BWAPI_CONFIG_AUTO_MENU__MAP=/torchcraft/maps/micro/m5v5_c_far.scm \
-   BWAPI_CONFIG_AUTO_MENU__GAME_TYPE="USE MAP SETTINGS" \
+   BWAPI_CONFIG_AUTO_MENU__GAME_TYPE="USE_MAP_SETTINGS" \
    TORCHCRAFT_PORT=11111 \
    BWAPILauncher
 ```
@@ -70,12 +70,12 @@ connection.
 7. `cd ~/.wine/drive_c/StarCraft`
 8. Launch Starcraft! `winegui bwheadless.exe -e StarCraft.exe -l bwapi-data/BWAPI.dll --headful`
 9. Use `docker ps` to find the container id of the torchcraft container, and run `docker exec -it $ID bash`
-   to jump into the container from a different terminal. From there, you can do things like 
+   to jump into the container from a different terminal. From there, you can do things like
    `cd ~/TorchCraft/examples && th simple_dll.lua -t localhost`
-   
+
 
 The sudo password to the image is `starcraft`
-   
+
 ## Saving and reloading
 This is a good time to [save a copy of your image](http://stackoverflow.com/questions/24482822/how-to-share-my-docker-image-without-using-the-docker-hub) in case it gets corrupted, so you don't have to go through that process again.
 

--- a/docker/openbw/Dockerfile
+++ b/docker/openbw/Dockerfile
@@ -46,8 +46,11 @@ RUN tar xvzf zeromq-4.2.2.tar.gz
 RUN cd zeromq-4.2.2 && ./configure && make install && ldconfig
 
 ## --------- zstd
-# TODO check if we need to install zstd from source
-RUN apt-get install -y libzstd1-dev zstd
+# This can only be done on 18.04, so commenting out for now
+# RUN apt-get install -y libzstd1-dev zstd
+RUN wget https://github.com/facebook/zstd/archive/v1.1.4.tar.gz
+RUN tar xf v1.1.4.tar.gz
+RUN cd zstd-1.1.4/ && make -j && make install && ldconfig
 
 ## --------- build BWEnv
 RUN cd torchcraft/BWEnv && mkdir build && cd build \

--- a/docker/openbw/Dockerfile
+++ b/docker/openbw/Dockerfile
@@ -1,0 +1,68 @@
+FROM nvidia/cuda:8.0-cudnn7-devel-ubuntu16.04
+MAINTAINER Nantas Nardelli
+
+# -------- build args
+ARG TC_BRANCH=master
+ARG TC_PORT=11111
+ARG OBW_GUI=1
+
+# -------- CUDA env
+ENV CUDA_PATH /usr/local/cuda
+ENV CUDA_INCLUDE_PATH /usr/local/cuda/include
+ENV CUDA_LIBRARY_PATH /usr/local/cuda/lib64
+
+# -------- Ubuntu Packages
+RUN apt-get update -y && apt-get install software-properties-common -y && \
+    add-apt-repository -y multiverse && apt-get update -y && apt-get upgrade -y && \
+    apt-get install -y apt-utils git nano vim man build-essential wget sudo && \
+    rm -rf /var/lib/apt/lists/*
+RUN apt-get update
+
+# -------- OpenBW
+
+## --------- compilation toolset
+RUN apt-get install -y libtool pkg-config build-essential autoconf automake uuid-dev cmake
+
+## --------- sdl
+RUN apt-get install -y libsdl2-dev libsdl2-2.0
+
+## --------- build OpenBW
+RUN git clone https://github.com/openbw/openbw
+RUN git clone https://github.com/openbw/bwapi
+RUN cd bwapi && mkdir build && cd build \
+    && cmake .. -DCMAKE_BUILD_TYPE=Release -DOPENBW_DIR=../../openbw -DOPENBW_ENABLE_UI=$OBW_GUI \
+    && make && make install
+
+# -------- TorchCraft
+
+RUN git clone https://github.com/torchcraft/torchcraft.git -b $TC_BRANCH --recursive
+
+## --------- zmq
+RUN apt-get purge -y libzmq*
+RUN apt-get install -y libtool pkg-config build-essential autoconf automake uuid-dev
+RUN wget https://github.com/zeromq/libzmq/releases/download/v4.2.2/zeromq-4.2.2.tar.gz
+RUN tar xvzf zeromq-4.2.2.tar.gz
+# RUN ulimit -n 1000 && apt-get update
+RUN cd zeromq-4.2.2 && ./configure && make install && ldconfig
+
+## --------- zstd
+# TODO check if we need to install zstd from source
+RUN apt-get install -y libzstd1-dev zstd
+
+## --------- build BWEnv
+RUN cd torchcraft/BWEnv && mkdir build && cd build \
+    && cmake .. -DCMAKE_BUILD_TYPE=relwithdebinfo \
+    && make -j
+
+# Installing the python client just in case
+## --------- python3
+RUN apt-get update
+RUN apt-get -y install python3
+RUN apt-get -y install python3-pip
+RUN pip3 install --upgrade pip
+
+## --------- python client deps
+RUN pip3 install pybind11
+
+## --------- python client
+RUN cd torchcraft && pip3 install .


### PR DESCRIPTION
This PR adds a docker image that compiles OpenBW and BWEnv so that they are ready to use together. 

The build does not assume that the MPQs are available, and thus they need to be mounted at runtime. I've added instructions on how to do so in the README.