### PR TITLE
Prevent concurrent connections from multiple clients

### DIFF
--- a/BWEnv/include/zmq_server.h
+++ b/BWEnv/include/zmq_server.h
@@ -30,6 +30,7 @@ class ZMQ_server
   std::unique_ptr<zmq::socket_t> sock;
   int port = 0;
   std::string file_socket;
+  std::string client_uid;
 public:
   bool server_sock_connected;
 

--- a/BWEnv/src/controller.cc
+++ b/BWEnv/src/controller.cc
@@ -242,7 +242,9 @@ void Controller::setupHandshake() {
   this->zmq_server->sendHandshake(&handshake);
 
   /* Receive first message (usually setup commands) */
-  this->zmq_server->receiveMessage();
+  while (!this->zmq_server->receiveMessage()) {
+    continue;
+  }
 
   this->resetFrameState();
 }
@@ -729,7 +731,9 @@ void Controller::endGame() {
 
   if (is_client) {
     // And receive new commands
-    this->zmq_server->receiveMessage();
+    while (!this->zmq_server->receiveMessage()) {
+      continue;
+    }
   } else {
     this->zmq_server->close();
   }
@@ -1379,7 +1383,7 @@ void Controller::setIsWinner(bool isWinner) {
 }
 
 void Controller::clearPendingReceive() {
-  if (!last_receive_ok) {
+  while (!last_receive_ok) {
     // The previous receive did not complete successfully. Perform a blocking
     // receive so that we're clear wrt the REQ/REP pattern.
     last_receive_ok = zmq_server->receiveMessage();


### PR DESCRIPTION
While it's possible to reconnect to a server and continue playing, controlling a
player with multiple clients at once is a strong indication that something is
wrong. It also results in clients receiving wrong (frame diff) data.

The ZMQ server will now keep track of the last client that performed a handshake
and will only accept commands from this client. Commands from any other client
will result in error messages being sent back. In blocking mode, the game will
not advance in this case; in non-blocking mode, the game will advance by one
frame but no commands will be executed.

With some refactoring, it would be possible to make this work correctly in
non-blocking mode as well. However, concurrent connections are considered an
error now (likely indicating another error in the client setup) and hence I
think that 100% correct operation will not be required.