### PR TITLE
Propagate server errors

### DIFF
--- a/client/client.cpp
+++ b/client/client.cpp
@@ -301,13 +301,9 @@ bool Client::receive(std::vector<std::string>& updates) {
     }
     case fbs::Any::Error: {
       auto error = as<fbs::Error>(msgData);
-      auto text = error->message();
-      std::cerr << "[Warning] Unhandled message from server: "
-                << fbs::EnumNameAny(msgType)
-                << "(message=\"" << (text ? text->str() : "(null)") << "\""
-                << std::endl;
-      updates = state_->update(error);
-      break;
+      error_ = std::string("Error from server: ") +
+          (error->message() ? error->message()->str() : "(Null)");
+      return false;
     }
     default:
       error_ = std::string("Error parsing reply: cannot handle message: ") +

--- a/client/state.cpp
+++ b/client/state.cpp
@@ -348,11 +348,6 @@ std::vector<std::string> State::update(
   return std::vector<std::string>();
 }
 
-std::vector<std::string> State::update(const fbs::Error* error) {
-  preUpdate();
-  return std::vector<std::string>();
-}
-
 bool State::setRawImage(const fbs::StateUpdate* frame) {
   if (frame->img_data()->size() !=
       static_cast<size_t>(

--- a/include/torchcraft/state.h
+++ b/include/torchcraft/state.h
@@ -146,7 +146,6 @@ class State : public RefCounted {
   std::vector<std::string> update(const fbs::StateUpdate* stateUpdate);
   std::vector<std::string> update(const fbs::EndGame* end);
   std::vector<std::string> update(const fbs::PlayerLeft* left);
-  std::vector<std::string> update(const fbs::Error* error);
   void trackAliveUnits(
       std::vector<std::string>& upd,
       const std::set<BW::UnitType>& considered);


### PR DESCRIPTION
`Client::receive()` will now return `false` upon error messages from the server.
`Client::error()` will contain the error message that was received.