### PR TITLE
Add frame_from_bwapi to server handshake

### DIFF
--- a/BWEnv/fbs/base.h
+++ b/BWEnv/fbs/base.h
@@ -99,7 +99,7 @@
 #endif // !defined(FLATBUFFERS_LITTLEENDIAN)
 
 #define FLATBUFFERS_VERSION_MAJOR 1
-#define FLATBUFFERS_VERSION_MINOR 7
+#define FLATBUFFERS_VERSION_MINOR 8
 #define FLATBUFFERS_VERSION_REVISION 0
 #define FLATBUFFERS_STRING_EXPAND(X) #X
 #define FLATBUFFERS_STRING(X) FLATBUFFERS_STRING_EXPAND(X)
@@ -186,14 +186,20 @@ template<typename T> T EndianSwap(T t) {
   if (sizeof(T) == 1) {   // Compile-time if-then's.
     return t;
   } else if (sizeof(T) == 2) {
-    auto r = FLATBUFFERS_BYTESWAP16(*reinterpret_cast<uint16_t *>(&t));
-    return *reinterpret_cast<T *>(&r);
+    union { T t; uint16_t i; } u;
+    u.t = t;
+    u.i = FLATBUFFERS_BYTESWAP16(u.i);
+    return u.t;
   } else if (sizeof(T) == 4) {
-    auto r = FLATBUFFERS_BYTESWAP32(*reinterpret_cast<uint32_t *>(&t));
-    return *reinterpret_cast<T *>(&r);
+    union { T t; uint32_t i; } u;
+    u.t = t;
+    u.i = FLATBUFFERS_BYTESWAP32(u.i);
+    return u.t;
   } else if (sizeof(T) == 8) {
-    auto r = FLATBUFFERS_BYTESWAP64(*reinterpret_cast<uint64_t *>(&t));
-    return *reinterpret_cast<T *>(&r);
+    union { T t; uint64_t i; } u;
+    u.t = t;
+    u.i = FLATBUFFERS_BYTESWAP64(u.i);
+    return u.t;
   } else {
     assert(0);
   }

--- a/BWEnv/fbs/flatbuffers.h
+++ b/BWEnv/fbs/flatbuffers.h
@@ -413,7 +413,7 @@ class DetachedBuffer {
     : allocator_(other.allocator_), own_allocator_(other.own_allocator_),
       buf_(other.buf_), reserved_(other.reserved_), cur_(other.cur_),
       size_(other.size_) {
-    other.reset();
+    other.reset();  
   }
 
   DetachedBuffer &operator=(DetachedBuffer &&other) {

--- a/BWEnv/fbs/gen.sh
+++ b/BWEnv/fbs/gen.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-flatcVersionRequired='1.7.1';
+flatcVersionRequired='1.8.0';
 flatcVersionCurrent=`flatc --version`;
 if [[ $flatcVersionCurrent == *"$flatcVersionRequired"* ]]; then
   flatc -c --gen-mutable --scoped-enums --gen-object-api --no-includes *.fbs

--- a/BWEnv/fbs/messages.fbs
+++ b/BWEnv/fbs/messages.fbs
@@ -48,6 +48,7 @@ table HandshakeServer {
   buildable_data:[ubyte];       // walk tile resolution of buildability
   start_locations:[Vec2];
   players:[Player];
+  frame_from_bwapi:int;
 }
 
 table Commands {

--- a/BWEnv/fbs/stl_emulation.h
+++ b/BWEnv/fbs/stl_emulation.h
@@ -20,6 +20,8 @@
 #include <string>
 #include <type_traits>
 #include <vector>
+#include <memory>
+#include <limits>
 
 #if defined(_STLPORT_VERSION) && !defined(FLATBUFFERS_CPP98_STL)
   #define FLATBUFFERS_CPP98_STL

--- a/BWEnv/include/zmq_server.h
+++ b/BWEnv/include/zmq_server.h
@@ -20,7 +20,7 @@ class Controller;
 
 class ZMQ_server
 {
-  static const int protocol_version = 30;
+  static const int protocol_version = 31;
   static const int max_commands = 2500; // maximum number of commands per frame
   static const int starting_port = 11111;
   static const int max_instances = 1000;

--- a/BWEnv/src/controller.cc
+++ b/BWEnv/src/controller.cc
@@ -226,6 +226,7 @@ void Controller::setupHandshake() {
     handshake.player_id = BWAPI::Broodwar->self()->getID();
   }
   handshake.battle_frame_count = battle_frame_count;
+  handshake.frame_from_bwapi = BWAPI::Broodwar->getFrameCount();
   for (auto loc : BWAPI::Broodwar->getStartLocations()) {
     BWAPI::WalkPosition walkPos(loc);
     handshake.start_locations.emplace_back(walkPos.x, walkPos.y);

--- a/client/client.cpp
+++ b/client/client.cpp
@@ -40,7 +40,7 @@ void buildHandshakeMessage(
     const torchcraft::Client::Options& opts,
     const std::string* uid = nullptr) {
   torchcraft::fbs::HandshakeClientT hsc;
-  hsc.protocol = 30;
+  hsc.protocol = 31;
   hsc.map = opts.initial_map;
   if (opts.window_size[0] >= 0) {
     hsc.window_size.reset(

--- a/client/state.cpp
+++ b/client/state.cpp
@@ -216,6 +216,8 @@ std::vector<std::string> State::update(const fbs::HandshakeServer* handshake) {
   upd.emplace_back("battle_frame_count");
   replay = handshake->is_replay();
   upd.emplace_back("replay");
+  frame_from_bwapi = handshake->frame_from_bwapi();
+  upd.emplace_back("frame_from_bwapi");
 
   postUpdate(upd);
   return upd;


### PR DESCRIPTION
This can be used for additional sanity checks in clients, e.g. when reconnecting
to a game that is already running.

I updated flatbuffers to 1.8.0, mostly because 1.7.1 can't be compiled from the
Github repo without additional effort (they did not add the correct version string
for the tag at https://github.com/google/flatbuffers/tree/v1.7.1).

EDIT: Naturally, this requires a bump for protocol version.