### PR TITLE
[Work in progress] OpenBW snapshot commands

### DIFF
--- a/BWEnv/include/controller.h
+++ b/BWEnv/include/controller.h
@@ -78,6 +78,9 @@ enum OBWCommands {
   SET_UNIT_HEALTH, // unit, health
   SET_UNIT_SHIELD, // unit, shield
   SET_UNIT_ENERGY, // unit, energy
+  SAVE_SNAPSHOT, // name
+  LOAD_SNAPSHOT, // name
+  DELETE_SNAPSHOT, // name
 };
 
 enum CommandStatus : int8_t {
@@ -116,7 +119,10 @@ class Controller {
       const std::vector<int>& args,
       const std::string& str);
   int8_t handleUserCommand(int command, const std::vector<int>& args);
-  int8_t handleOpenBWCommand(int command, const std::vector<int>& args);
+  int8_t handleOpenBWCommand(
+      int command,
+      const std::vector<int>& args,
+      const std::string& str);
   void setCommandsStatus(std::vector<int8_t> status);
   BWAPI::Position getPositionFromWalkTiles(int x, int y);
   BWAPI::TilePosition getTilePositionFromWalkTiles(int x, int y);

--- a/BWEnv/src/controller.cc
+++ b/BWEnv/src/controller.cc
@@ -520,6 +520,9 @@ int8_t Controller::handleCommand(
             {OBWCommands::SET_UNIT_HEALTH, 2},
             {OBWCommands::SET_UNIT_SHIELD, 2},
             {OBWCommands::SET_UNIT_ENERGY, 2},
+            {OBWCommands::SAVE_SNAPSHOT, 0},
+            {OBWCommands::LOAD_SNAPSHOT, 0},
+            {OBWCommands::DELETE_SNAPSHOT, 0},
         };
         if (!check_args(obw_argcount[command]))
           return status;
@@ -528,7 +531,7 @@ int8_t Controller::handleCommand(
         auto last = args.end();
         std::vector<int> user_args(second, last);
 
-        return handleOpenBWCommand(type, user_args);
+        return handleOpenBWCommand(type, user_args, str);
       }
     }
   }
@@ -538,7 +541,8 @@ int8_t Controller::handleCommand(
 
 int8_t Controller::handleOpenBWCommand(
     int command,
-    const std::vector<int>& args) {
+    const std::vector<int>& args,
+    const std::string& str) {
 #ifndef OPENBW_BWAPI
   return CommandStatus::OPENBW_NOT_IN_USE;
 #else
@@ -617,6 +621,27 @@ int8_t Controller::handleOpenBWCommand(
         return CommandStatus::INVALID_UNIT;
       }
       u->setEnergy(args[1]);
+      return CommandStatus::SUCCESS;
+    }
+    case OBWCommands::SAVE_SNAPSHOT: {
+      if (str == "") {
+        return CommandStatus::MISSING_ARGUMENTS;
+      }
+      BWAPI::Broodwar->saveSnapshot(str);
+      return CommandStatus::SUCCESS;
+    }
+    case OBWCommands::LOAD_SNAPSHOT: {
+      if (str == "") {
+        return CommandStatus::MISSING_ARGUMENTS;
+      }
+      BWAPI::Broodwar->loadSnapshot(str);
+      return CommandStatus::SUCCESS;
+    }
+    case OBWCommands::DELETE_SNAPSHOT: {
+      if (str == "") {
+        return CommandStatus::MISSING_ARGUMENTS;
+      }
+      BWAPI::Broodwar->deleteSnapshot(str);
       return CommandStatus::SUCCESS;
     }
   }

--- a/include/torchcraft/constants.h
+++ b/include/torchcraft/constants.h
@@ -101,7 +101,7 @@ BETTER_ENUM(
     SetUnitEnergy = 8, // unit, energy
     SaveSnapshot = 9, // name
     LoadSnapshot = 10, // name
-    DeleteSnapshot = 11 // name
+    DeleteSnapshot = 11, // name
 
     OPENBW_COMMAND_END = 2)
 

--- a/include/torchcraft/constants.h
+++ b/include/torchcraft/constants.h
@@ -99,6 +99,9 @@ BETTER_ENUM(
     SetUnitHealth = 6, // unit, health
     SetUnitShield = 7, // unit, shield
     SetUnitEnergy = 8, // unit, energy
+    SaveSnapshot = 9, // name
+    LoadSnapshot = 10, // name
+    DeleteSnapshot = 11 // name
 
     OPENBW_COMMAND_END = 2)
 


### PR DESCRIPTION
Adding support for OpenBW's capability to save/restore/delete snapshots of game state in memory. This can be used to quickly (and safely) reset OpenBW's state.

(TODO: Actually testing that it works)