### PR TITLE
Fix Color::Orange value

### DIFF
--- a/include/torchcraft/constants.h
+++ b/include/torchcraft/constants.h
@@ -823,7 +823,7 @@ BETTER_ENUM(
     Teal = 159,
     Purple = 164,
     Blue = 165,
-    Orange = -179,
+    Orange = 179,
     White = 255)
 
 constexpr int XYPixelsPerWalktile = 8;


### PR DESCRIPTION
**TEST PLAN**
CherryVis: above is `-179` (whatever that means), below is `179`
![image](https://user-images.githubusercontent.com/43445237/58871748-e5482a00-86c2-11e9-89ea-6be1ead45c77.png)
